### PR TITLE
xmlrpc: remember to call super class constructor

### DIFF
--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -542,6 +542,7 @@ class SafeCookieTransport(xmlrpclib.SafeTransport, CookieTransport):
         request = CookieTransport._request
 
     def __init__(self, *args, **kwargs):
+        xmlrpclib.SafeTransport.__init__(self, *args, **kwargs)
         CookieTransport.__init__(self, *args, **kwargs)
 
     def send_request(self, connection, handler, request_body):


### PR DESCRIPTION
... in SafeCookieTransport to make https:// hub URLs work on Fedora 23.

Without this patch, covscan client fails with the following backtrace:

```
Traceback (most recent call last):
  File "/usr/bin/covscan", line 55, in <module>
    sys.exit(main())
  File "/usr/bin/covscan", line 47, in main
    parser.run(args)
  File "/usr/lib/python2.7/site-packages/kobo/cli.py", line 273, in run
    cmd.run(*cmd_args, **cmd_kwargs)
  File "/usr/lib/python2.7/site-packages/covscan/commands/cmd_list_mock_configs.py", line 33, in run
    self.set_hub(username, password)
  File "/usr/lib/python2.7/site-packages/kobo/client/__init__.py", line 109, in set_hub
    self.hub = HubProxy(conf=self.conf)
  File "/usr/lib/python2.7/site-packages/kobo/client/__init__.py", line 153, in __init__
    self._login(verbose=self._conf.get("DEBUG_XMLRPC"))
  File "/usr/lib/python2.7/site-packages/kobo/client/__init__.py", line 189, in _login
    if force or self._hub.auth.renew_session():
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1240, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1599, in __request
    verbose=self.__verbose
  File "/usr/lib/python2.7/site-packages/kobo/xmlrpc.py", line 568, in request
    result = transport_class.request(self, *args, **kwargs)
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1280, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python2.7/site-packages/kobo/xmlrpc.py", line 436, in _single_request
    h = self.make_connection(host)
  File "/usr/lib/python2.7/site-packages/kobo/xmlrpc.py", line 530, in make_connection
    conn = xmlrpclib.SafeTransport.make_connection(self, host)
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1517, in make_connection
    self._connection = host, HTTPS(chost, None, context=self.context, **(x509 or {}))
AttributeError: SafeCookieTransport instance has no attribute 'context'
```