### PR TITLE
Http proxy fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/*
 dist/*
 MANIFEST
 .spyderproject
+*.un~

--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -80,8 +80,8 @@ class TimeoutHTTPProxyConnection(TimeoutHTTPConnection):
         self.putheader("Proxy-Authorization", "Basic %s" % enc_userpass)
 
     def set_host_and_port(self, host, port):
-        """Due to httplib.py changes using set host & port method depends on python version"""
-        if sys.version_info[:2] < (2, 7):
+        """Due to httplib.py changes using set host & port method depends on package version"""
+        if hasattr(self, "_set_hostport"):
             self._set_hostport(host, port)
         else:
             (self.host, self.port) = self._get_hostport(host, port)

--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -50,16 +50,16 @@ class TimeoutHTTPProxyConnection(TimeoutHTTPConnection):
     def __init__(self, host, proxy, port=None, proxy_user=None, proxy_password=None, **kwargs):
         TimeoutHTTPConnection.__init__(self, proxy, **kwargs)
         self.proxy, self.proxy_port = self.host, self.port
-        self._set_hostport(host, port)
+        self.set_host_and_port(host, port)
         self.real_host, self.real_port = self.host, self.port
         self.proxy_user = proxy_user
         self.proxy_password = proxy_password
 
     def connect(self):
         # Connect to the proxy
-        self._set_hostport(self.proxy, self.proxy_port)
+        self.set_host_and_port(self.proxy, self.proxy_port)
         httplib.HTTPConnection.connect(self)
-        self._set_hostport(self.real_host, self.real_port)
+        self.set_host_and_port(self.real_host, self.real_port)
         timeout = getattr(self, "_timeout", 0)
         if timeout:
             self.sock.settimeout(timeout)
@@ -79,6 +79,12 @@ class TimeoutHTTPProxyConnection(TimeoutHTTPConnection):
         enc_userpass = base64.encodestring(userpass).strip()
         self.putheader("Proxy-Authorization", "Basic %s" % enc_userpass)
 
+    def set_host_and_port(self, host, port):
+        """Due to httplib.py changes using set host & port method depends on python version"""
+        if sys.version_info[:2] < (2, 7):
+            self._set_hostport(host, port)
+        else:
+            (self.host, self.port) = self._get_hostport(host, port)
 
 class TimeoutHTTP(httplib.HTTP):
     _connection_class = TimeoutHTTPConnection
@@ -575,7 +581,8 @@ def retry_request_decorator(transport_class):
                         raise
                     retries_left = self.retry_count - i
                     retries = "%d %s left" % (retries_left, retries_left == 1 and "retry" or "retries") # 1 retry left / X retries left
-                    print >> sys.stderr, "XML-RPC connection to %s failed: %s, %s" % (args[0], " ".join(ex.args[1:]), retries)
+                    print >> sys.stderr, "XML-RPC connection to %s failed: %s, %s" % (args[0], ex.args[1:], retries)
+                    raise
                     time.sleep(self.retry_timeout)
 
     RetryTransportClass.__name__ = transport_class.__name__


### PR DESCRIPTION
The main problem was with the `_set_hostport` method which was replaced by `_get_hostport`. Currently it uses method according to hasattr. When `_get_hostport` isn't used correctly, it malforms proxy and port and that's why it looked like a bigger problem. Tested on RHEL6, RHEL7, Fedora23, both http and https proxy. 