### PR TITLE
Add __setitem__ to FileCache

### DIFF
--- a/kobo/pkgset.py
+++ b/kobo/pkgset.py
@@ -225,6 +225,9 @@ class FileCache(object):
     def __getitem__(self, name):
         return self.file_cache[os.path.abspath(name)]
 
+    def __setitem__(self, name, value):
+        self.file_cache[os.path.abspath(name)] = value
+
     def __iter__(self):
         return self.file_cache.iterkeys()
 

--- a/tests/test_pkgset.py
+++ b/tests/test_pkgset.py
@@ -153,6 +153,18 @@ class TestFileCacheClass(unittest.TestCase):
         self.assertEqual(id(self.cache[self.file1]), id(wrap1))
         self.assertEqual(id(self.cache[self.file2]), id(wrap2))
 
+    def test_setitem(self):
+        open(self.file1, "w").write("hello\n")
+
+        self.cache1 = FileCache()
+        self.cache2 = FileCache()
+        wrap = self.cache1.add(self.file1)
+
+        self.cache2[self.file1] = wrap
+
+        self.assertEqual(len(self.cache2.file_cache), 1)
+        self.assertEqual(id(self.cache2[self.file1]), id(wrap))
+
     def test_iteritems(self):
         open(self.file1, "w").write("hello\n")
         open(self.file2, "w").write("hello\n")


### PR DESCRIPTION
This method is useful when mergin package sets. Without the patch, a
user must access the `file_cache` instance attribute which is arguably
not nice.

Fixes: #12