### PR TITLE
Closed tasks can be interrupted without throwing an exception

### DIFF
--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -5,6 +5,9 @@ import sys
 import datetime
 import gzip
 import shutil
+import logging
+
+logger =  logging.getLogger("kobo")
 
 try:
     import json
@@ -615,7 +618,11 @@ WHERE
             cursor.execute(query, (new_state, new_worker_id, dt_started, dt_finished, waiting, self.id, worker_id))
 
             if cursor.rowcount == 0:
-                raise ObjectDoesNotExist()
+                if self.state in FINISHED_STATES:
+                    logger.debug("Trying to interrupt closed task %s, ignoring.", self.id)
+                    return
+                else:
+                    raise ObjectDoesNotExist()
 
             if cursor.rowcount > 1:
                 raise MultipleObjectsReturned()


### PR DESCRIPTION
When errata diff build has been running twice in a row and the first one had subtask already finished, it wasn't able to interrupt subtask successfully. Interrupting tasks was running periodically which created an infinite loop in covscan and task run forever until killed manually. Kobo was looking in DB for task in opened state and got zero rows, which produced exception. Now it throws exception only if the task is not in closed state. When it is trying to interrupt closed task, nothing happens - only the attempt is logged (covscan logger conf is extended).