### PR TITLE
Fix parse error on comment on import line

### DIFF
--- a/kobo/conf.py
+++ b/kobo/conf.py
@@ -166,7 +166,7 @@ class PyConfigParser(dict):
 
         # skip some tokens
         if self._tok_name in ["COMMENT", "INDENT", "DEDENT"]:
-            self._get_token()
+            self._get_token(skip_newline=skip_newline)
 
         if skip_newline and self._tok_name in ["NL", "NEWLINE"]:
             self._get_token()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,11 +1,16 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 
 import unittest
+import tempfile
+import shutil
+import os
 import run_tests # set sys.path
 
 from kobo.conf import *
+from kobo.conf import PyConfigParser
 
 
 CONFIG = """
@@ -92,6 +97,27 @@ class TestConf(unittest.TestCase):
         self.assertEqual(self.conf["list1"], [])
         self.assertEqual(self.conf["list2"], [1])
         self.assertEqual(self.conf["list3"], [1, "a"])
+
+
+class TestImport(unittest.TestCase):
+    def setUp(self):
+        self.conf = PyConfigParser()
+        self.dir = tempfile.mkdtemp()
+        self.file = os.path.join(self.dir, 'extend.conf')
+
+    def tearDown(self):
+        shutil.rmtree(self.dir)
+
+    def test_import_empty_file_with_inline_comment(self):
+        with open(os.path.join(self.dir, 'base.conf'), 'w') as f:
+            print('a = 1', file=f)
+
+        with open(self.file, 'w') as f:
+            print('from base import * # really', file=f)
+            print('b = 1', file=f)
+
+        self.conf.load_from_file(self.file)
+        self.assertEqual(self.conf, dict(a=1, b=1))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Minimal example:

    from x import * #
    a = 1

This commit adds a test and fix for this.

The root cause is that when `_get_token(skip_newline=False)` encounters a comment, it will call itself without any argument, and so use the default of `True` to skip next new line. The fix is to pass down the correct argument.