### PR TITLE
Add logfile path to error message

### DIFF
--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -328,6 +328,9 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
         stdin_thread.join()
 
     err_msg = "ERROR running command: %s" % cmd
+    if logfile:
+        err_msg += "\nFor more details see %s" % logfile
+
     if proc.returncode != 0 and show_cmd:
         print >> sys.stderr, err_msg
 


### PR DESCRIPTION
When `kobo.shortcuts.run` has a log file and the command fails, the
exception text should include the path. This will make it much easier to
debug why the command fails.