### PR TITLE
kobo.conf: store opened files in a list

### DIFF
--- a/kobo/conf.py
+++ b/kobo/conf.py
@@ -85,6 +85,8 @@ class PyConfigParser(dict):
         self._config_file_suffix = config_file_suffix
         self._debug = debug
         self._open_file = None
+        # list of config files in abspath, includes all imported config files
+        self.opened_files = []
 
     def __getitem__(self, name):
         if name.startswith("_"):
@@ -102,6 +104,7 @@ class PyConfigParser(dict):
         data = fo.read()
         fo.close()
         self._open_file = file_name
+        self.opened_files.append(os.path.abspath(file_name))
         self.load_from_string(data)
 
     def load_from_string(self, input_string):
@@ -264,6 +267,7 @@ class PyConfigParser(dict):
 
         imported_config = self.__class__(config_file_suffix=self._config_file_suffix, debug=self._debug)
         imported_config.load_from_file(file_name)
+        self.opened_files.extend(imported_config.opened_files)
 
         if "*" in imports:
             self.load_from_dict(imported_config)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -119,6 +119,18 @@ class TestImport(unittest.TestCase):
         self.conf.load_from_file(self.file)
         self.assertEqual(self.conf, dict(a=1, b=1))
 
+    def test_opened_files(self):
+        with open(os.path.join(self.dir, 'base.conf'), 'w') as f:
+            print('a = 1', file=f)
+
+        with open(self.file, 'w') as f:
+            print('from base import * # really', file=f)
+            print('b = 1', file=f)
+
+        self.conf.load_from_file(self.file)
+        self.assertTrue(self.file in self.conf.opened_files)
+        self.assertTrue(os.path.join(self.dir, 'base.conf') in self.conf.opened_files)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Sometimes we want to save the original config files for debugging
issues, but it's inconvenient to know which config files are loaded
when the syntax of 'from <config> import <variables/*>' is used.
Store the opened files in a list can make it much easier.