### PR TITLE
run: Raise exception before printing error

### DIFF
--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -332,7 +332,9 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
         err_msg += "\nFor more details see %s" % logfile
 
     if proc.returncode != 0 and not can_fail:
-        raise RuntimeError(err_msg)
+        exc = RuntimeError(err_msg)
+        exc.output = output
+        raise exc
 
     if proc.returncode != 0 and show_cmd:
         print >> sys.stderr, err_msg

--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -331,11 +331,11 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
     if logfile:
         err_msg += "\nFor more details see %s" % logfile
 
-    if proc.returncode != 0 and show_cmd:
-        print >> sys.stderr, err_msg
-
     if proc.returncode != 0 and not can_fail:
         raise RuntimeError(err_msg)
+
+    if proc.returncode != 0 and show_cmd:
+        print >> sys.stderr, err_msg
 
     if not return_stdout:
         output = None


### PR DESCRIPTION
If the command failed and was not allowed to, we should not print the error message to stderr. The calling code will receive the same message in an exception and should be free to decide whether it should be printed somewhere.

The case when the command could fail is left unchanged. There is no easy way to return the additional error message without changing the API of the function. However this case can be ignored as any caller can mark the command as non-failable and just ignore the exception.

Fixes: #25