### PR TITLE
xmlrpc: Fix unexpected 'context' argument on python <= 2.7.9.

### DIFF
--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -548,6 +548,7 @@ class SafeCookieTransport(xmlrpclib.SafeTransport, CookieTransport):
         request = CookieTransport._request
 
     def __init__(self, *args, **kwargs):
+        self.context = kwargs.pop('context', None)
         xmlrpclib.SafeTransport.__init__(self, *args, **kwargs)
         CookieTransport.__init__(self, *args, **kwargs)
 


### PR DESCRIPTION
It fixes following problem:
```
  File "/usr/lib/python2.7/site-packages/kobo/cli.py", line 273, in run
    cmd.run(*cmd_args, **cmd_kwargs)
  File "/usr/lib/python2.7/site-packages/pub/commands/cmd_push_docker.py", line 97, in run
    self.set_hub(username, password)
  File "/usr/lib/python2.7/site-packages/kobo/client/__init__.py", line 110, in set_hub
    self.hub = HubProxy(conf=self.conf)
  File "/usr/lib/python2.7/site-packages/kobo/client/__init__.py", line 159, in __init__
    self._transport = TransportClass(**transport_args)
  File "/usr/lib/python2.7/site-packages/kobo/xmlrpc.py", line 568, in __init__
    transport_class.__init__(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/kobo/xmlrpc.py", line 551, in __init__
    xmlrpclib.SafeTransport.__init__(self, *args, **kwargs)
TypeError: __init__() got an unexpected keyword argument '\''context'\''
```

Please note the 'context' argument is supported since python 2.7.9 and the behavior on previous python versions may differ or it may not work at all.