### PR TITLE
conf: Report error for duplicate keys

### DIFF
--- a/kobo/conf.py
+++ b/kobo/conf.py
@@ -70,6 +70,11 @@ def get_dict_value(dictionary, key):
         raise
 
 
+def _type_equal(a, b):
+    """Check if two values have the same type and are equal."""
+    return type(a) == type(b) and a == b
+
+
 class PyConfigParser(dict):
     """Python-like syntax config parser."""
 
@@ -294,6 +299,16 @@ class PyConfigParser(dict):
                 break
 
             key = self._get_value(get_next=False, basic_types_only=True)
+
+            # Check for an already present key. This would silently overwrite
+            # the previous value, but most likely this is a user error in the
+            # configuration that should be reported.
+            if any(_type_equal(key, k) for k in result):
+                # The condition can not use `key in result` as that would
+                # report a problem with {1: 1, True: True} because True == 1.
+                line, _ = self._tok_begin
+                raise SyntaxError('Duplicate dict key %r in file %s on line %s'
+                                  % (key, self._open_file, line))
 
             self._get_token()
             self._assert_token(("OP", ":"))

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -132,5 +132,20 @@ class TestImport(unittest.TestCase):
         self.assertTrue(os.path.join(self.dir, 'base.conf') in self.conf.opened_files)
 
 
+class TestDuplicateKeys(unittest.TestCase):
+    def test_duplicate_keys(self):
+        cfg = """foo = {
+            "bar": 1,
+            "bar": 2,
+        }
+        """
+        conf = PyConfigParser()
+        with self.assertRaises(SyntaxError) as ctx:
+            conf.load_from_string(cfg)
+
+        self.assertEqual(str(ctx.exception),
+                         "Duplicate dict key 'bar' in file None on line 3")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Current behaviour is that the latter value wins. However if the config contains the same key multiple times, it's most likely an error in the config. If the shadowing is really wanted, it's trivial to comment out or delete the original key.

Related issue: https://pagure.io/pungi/issue/564