### PR TITLE
Report better error on undefined variable

### DIFF
--- a/kobo/conf.py
+++ b/kobo/conf.py
@@ -186,7 +186,11 @@ class PyConfigParser(dict):
             return None
 
         # return already defined variable
-        return self[self._tok_value]
+        try:
+            return self[self._tok_value]
+        except KeyError:
+            raise SyntaxError("Undefined variable %r: file: %s, begin: %s, end: %s, text: %s"
+                              % (self._tok_value, self._open_file, self._tok_begin, self._tok_end, self._tok_line))
 
     def _get_STRING(self):
         """Return a STRING token value."""

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -132,5 +132,25 @@ class TestImport(unittest.TestCase):
         self.assertTrue(os.path.join(self.dir, 'base.conf') in self.conf.opened_files)
 
 
+class TestUndefinedVariable(unittest.TestCase):
+    def setUp(self):
+        self.conf = PyConfigParser()
+
+    def test_import_empty_file_with_inline_comment(self):
+        cfg = '''
+        a = [
+            'b',
+            missing start of comment
+            'c',
+        ]
+        '''
+
+        with self.assertRaises(SyntaxError) as ctx:
+            self.conf.load_from_string(cfg)
+
+        self.assertRegexpMatches(str(ctx.exception),
+                                 "Undefined variable 'missing': .+")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Instead of dying with a cryptic `KeyError`, we should report correct location where the problem is.