### PR TITLE
Report errors in add_file_logger

### DIFF
--- a/kobo/log.py
+++ b/kobo/log.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+import errno
 import os
 import logging
 import logging.handlers
@@ -87,6 +88,13 @@ def add_file_logger(logger, logfile, log_level=None, format=None, mode="a"):
     """Add a file logger to the logger."""
     log_level = log_level or logging.DEBUG
     format = format or BRIEF_LOG_FORMAT
+
+    # Create parent directory if needed.
+    try:
+        os.makedirs(os.path.dirname(logfile))
+    except OSError as exc:
+        if exc.errno != errno.EEXIST:
+            raise
 
     # touch the logfile
     if not os.path.exists(logfile):

--- a/kobo/log.py
+++ b/kobo/log.py
@@ -5,6 +5,7 @@ import errno
 import os
 import logging
 import logging.handlers
+import warnings
 
 
 __all__ = (
@@ -84,8 +85,26 @@ def add_stream_handler(logger, log_level=None, format=None, stream=None):
     logger.addHandler(handler)
 
 
+class KoboLogWarning(UserWarning):
+    """Just like a UserWarning, but with a custom name for better filtering."""
+    pass
+
+
+def _warn(msg, *args):
+    """Report a warning pointing to a line that called whatever function called
+    _warn.
+    """
+    warnings.warn(msg % args, KoboLogWarning, stacklevel=3)
+
+
 def add_file_logger(logger, logfile, log_level=None, format=None, mode="a"):
-    """Add a file logger to the logger."""
+    """Add a file logger to the logger.
+
+    When there is a problem with the log file, a warning is logged. It can be
+    turned into an exception by running:
+
+    > warnings.simplefilter('error', kobo.log.KoboLogWarning)
+    """
     log_level = log_level or logging.DEBUG
     format = format or BRIEF_LOG_FORMAT
 
@@ -94,22 +113,26 @@ def add_file_logger(logger, logfile, log_level=None, format=None, mode="a"):
         os.makedirs(os.path.dirname(logfile))
     except OSError as exc:
         if exc.errno != errno.EEXIST:
-            raise
+            _warn('Could not create %s: %s', os.path.dirname(logfile), exc)
+            return
 
     # touch the logfile
     if not os.path.exists(logfile):
         try:
             fo = open(logfile, "w")
             fo.close()
-        except (ValueError, IOError):
+        except IOError as exc:
+            _warn('Could not touch %s: %s', logfile, exc)
             return
 
     # is the logfile really a file?
     if not os.path.isfile(logfile):
+        _warn('Can not log into %s: not a file', logfile)
         return
 
     # check if the logfile is writable
     if not os.access(logfile, os.W_OK):
+        _warn('Can not log into %s: not writable', logfile)
         return
 
     handler = logging.FileHandler(logfile, mode=mode)


### PR DESCRIPTION
Currently if there is any problem with creating the log file, no error is reported and from calling code everything looks fine. Except there are no logs.

This pull requests adds exceptions whenever something is wrong with the log file, and it also creates the target directory if it's missing.