### PR TITLE
Add more docstrings to threading module

### DIFF
--- a/kobo/threads.py
+++ b/kobo/threads.py
@@ -94,7 +94,7 @@ class ThreadPool(kobo.log.LoggingBase):
         self.threads.append(thread)
 
     def start(self):
-        """Start all worker threads and immediatelly return."""
+        """Start all worker threads and immediately return."""
         for i in self.threads:
             i.running = True
             i.kill = False

--- a/kobo/threads.py
+++ b/kobo/threads.py
@@ -94,12 +94,21 @@ class ThreadPool(kobo.log.LoggingBase):
         self.threads.append(thread)
 
     def start(self):
+        """Start all worker threads and immediatelly return."""
         for i in self.threads:
             i.running = True
             i.kill = False
             i.start()
 
     def stop(self):
+        """Wait for the worker threads to process all items in queue.
+
+        This method blocks until there is no more work left.
+
+        It is essential to call this method. If you do any work in between
+        ``start`` and ``stop``, make sure the ``stop`` method will always be
+        called, otherwise the program will never exit.
+        """
         for i in self.threads:
             i.running = False
         for i in self.threads:


### PR DESCRIPTION
The mentioned race condition can be replicated with this snippet:

```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

import kobo.threads


class MyThread(kobo.threads.WorkerThread):
    def process(self, item, num):
        pass


pool1 = kobo.threads.ThreadPool()
pool1.add(MyThread(pool1))

pool1.start()
1/0
pool1.stop()
```

The `stop` method will not be called, but despite printing the traceback the program will not exit (and not react to Ctrl-C either).