### PR TITLE
Fix unbounded memory usage when viewing logs

### DIFF
--- a/kobo/client/commands/cmd_watch_log.py
+++ b/kobo/client/commands/cmd_watch_log.py
@@ -64,7 +64,14 @@ class Watch_Log(ClientCommand):
             if data['content']:
                 sys.stdout.write(data['content'])
                 sys.stdout.flush()
-            if data['task_finished'] == 1 or kwargs['nowait']:
-                 break
+            if kwargs['nowait']:
+                break
+            next_poll = data.get('next_poll')
+            if data['task_finished'] == 1 and next_poll is None:
+                break
             offset = data['new_offset']
-            time.sleep(kwargs['poll'])
+
+            # If next_poll is 0, that means there's immediately more content, so fetch
+            # it now. Otherwise, stick with the user's requested poll interval
+            if next_poll != 0:
+                time.sleep(kwargs['poll'])

--- a/kobo/hub/static/kobo/js/log_watcher.js
+++ b/kobo/hub/static/kobo/js/log_watcher.js
@@ -28,21 +28,22 @@ function GET_handler(log_watcher) {
 }
 
 function doWatch() {
-	if (!document.log_watcher.task_finished) {
-		client = getAjax();
-		client.onreadystatechange = GET_handler;
-		client.open('GET', document.log_watcher.json_url + '?offset=' + document.log_watcher.offset);
-		client.send();
+	var need_poll = (!document.log_watcher.task_finished || document.log_watcher.next_poll != null);
+	if (!need_poll) {
+		return;
 	}
-	if (!document.log_watcher.task_finished) {
-		setTimeout(doWatch, 5000);
-	}
+	client = getAjax();
+	client.onreadystatechange = GET_handler;
+	client.open('GET', document.log_watcher.json_url + '?offset=' + document.log_watcher.offset);
+	client.send();
+	setTimeout(doWatch, document.log_watcher.next_poll || 5000);
 }
 
-function LogWatcher(json_url, offset, task_finished) {
+function LogWatcher(json_url, offset, task_finished, next_poll) {
 	this.json_url = json_url;
 	this.offset = offset;
 	this.task_finished = task_finished;
+	this.next_poll = next_poll;
 	this.page_height = 0;
 	return this;
 }

--- a/kobo/hub/templates/task/log.html
+++ b/kobo/hub/templates/task/log.html
@@ -4,7 +4,7 @@
 {% block head %}
 <script type="text/javascript" src="{{ STATIC_URL }}kobo/js/log_watcher.js"></script>
 <script type="text/javascript" language="javascript">
-document.log_watcher = new LogWatcher('{{ json_url }}', {{ offset }}, {{ task_finished }});
+document.log_watcher = new LogWatcher('{{ json_url }}', {{ offset }}, {{ task_finished }}, {{ next_poll }});
 document.log_watcher.watch();
 </script>
 {% endblock %}

--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -153,7 +153,7 @@ def task_log(request, id, log_name):
     if not found:
         return HttpResponseForbidden("Can display only specific file types: %s" % ", ".join(exts))
 
-    content = task.logs[log_name][offset:]
+    content = task.logs.get_chunk(log_name, offset)
     content = content.decode("utf-8", "replace")
     context = {
         "title": "Task log",
@@ -174,7 +174,7 @@ def task_log_json(request, id, log_name):
 
     task = get_object_or_404(Task, id=id)
     offset = int(request.GET.get("offset", 0))
-    content = task.logs[log_name][offset:]
+    content = task.logs.get_chunk(log_name, offset)
 
     result = {
         "new_offset": offset + len(content),

--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -26,6 +26,9 @@ from kobo.django.views.generic import ExtraDetailView, SearchView
 # max log size returned in HTML-embedded view
 HTML_LOG_MAX_SIZE = getattr(settings, "HTML_LOG_MAX_SIZE", (1024 ** 2) * 2)
 
+# default LogWatcher JS poll interval
+LOG_WATCHER_INTERVAL = getattr(settings, "LOG_WATCHER_INTERVAL", 5000)
+
 
 class UserDetailView(ExtraDetailView):
     model = get_user_model()
@@ -177,6 +180,7 @@ def task_log(request, id, log_name):
         "title": "Task log",
         "offset": offset + content_len + 1,
         "task_finished": task.is_finished() and 1 or 0,
+        "next_poll": None if task.is_finished() else LOG_WATCHER_INTERVAL,
         "content": content,
         "log_name": log_name,
         "task": task,
@@ -197,6 +201,7 @@ def task_log_json(request, id, log_name):
     result = {
         "new_offset": offset + len(content),
         "task_finished": task.is_finished() and 1 or 0,
+        "next_poll": None if task.is_finished() else LOG_WATCHER_INTERVAL,
         "content": content,
     }
 

--- a/tests/test_task_logs.py
+++ b/tests/test_task_logs.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+
+from shutil import rmtree
+
+import django
+import django.conf
+import django.test
+from django.test.utils import get_runner
+from django.shortcuts import get_object_or_404
+
+
+# Only for Django >= 1.7
+if 'setup' in dir(django):
+    # This has to happen before below imports because they have a hard requirement
+    # on settings being loaded before import.
+    django.setup()
+
+from kobo.hub.models import Task, Arch, Channel
+from django.contrib.auth.models import User
+
+TASK_ID = 123
+
+class TestTaskLogs(django.test.TestCase):
+    def cleanDataDirs(self):
+        """Delete the log directory for the test task."""
+        log_dir = os.path.join(django.conf.settings.TASK_DIR, '0', '0', str(TASK_ID))
+        if os.path.exists(log_dir):
+            rmtree(log_dir)
+
+    def tearDown(self):
+        self.cleanDataDirs()
+
+        super(TestTaskLogs, self).tearDown()
+
+    def setUp(self):
+        super(TestTaskLogs, self).setUp()
+
+        self.cleanDataDirs()
+
+        # These objects are required to exist but their attributes are irrelevant
+        user = User.objects.create()
+        arch = Arch.objects.create(name='testarch')
+        channel = Channel.objects.create(name='testchannel')
+
+        test_task = Task.objects.create(
+            pk=TASK_ID, arch=arch, channel=channel, owner=user)
+
+        self.log_content = log_content = 'Line 1 ☺\nLine 2 ☺\nLine 3'
+
+        test_task.logs['test_compressed.log'] = log_content
+        test_task.logs.save()
+        test_task.logs.gzip_logs()
+
+        test_task.logs['test.log'] = log_content
+        test_task.logs.save()
+
+    def task_logs(self):
+        return get_object_or_404(Task, id=TASK_ID).logs
+
+    def test_read_log_typical(self):
+        task_logs = self.task_logs()
+        log_content = task_logs['test.log']
+        self.assertEqual(log_content, self.log_content)
+
+        # It should be in the cache
+        self.assertEqual(log_content, task_logs.cache['test.log'])
+
+    def test_read_log_compressed(self):
+        task_logs = self.task_logs()
+
+        log_content = task_logs['test_compressed.log']
+        self.assertEqual(log_content, self.log_content)
+
+        # It should be in the cache
+        self.assertEqual(log_content, task_logs.cache['test_compressed.log'])
+
+    def test_get_chunk_missing(self):
+        do_call = lambda: self.task_logs().get_chunk('notexist.log')
+        self.assertRaises(Exception, do_call)
+
+    def test_get_chunk_all(self):
+        self.assertEqual(self.task_logs().get_chunk('test.log'), self.log_content)
+
+    def test_get_chunk_offset(self):
+        chunk = self.task_logs().get_chunk('test.log', offset=len(b'Line 1 ☺\n'))
+        self.assertEqual(chunk, b'Line 2 ☺\nLine 3')
+
+    def test_get_chunk_offset_len(self):
+        self.do_chunk_offset_len_test('test.log')
+        self.do_chunk_offset_len_test('test_compressed.log')
+
+    def do_chunk_offset_len_test(self, log_name):
+        chunk = self.task_logs().get_chunk(log_name, offset=1, length=2)
+        self.assertEqual(chunk, b'in')
+
+    def test_chunk_offset_len_from_cache(self):
+        task_logs = self.task_logs()
+
+        # First, read the entire log.
+        self.assertEqual(self.log_content, task_logs['test.log'])
+
+        # Now, if I request a chunk, it comes directly from the cache
+        # rather than reading from disk again, proven by deleting
+        # the log dir before requesting chunk
+        self.cleanDataDirs()
+
+        chunk = task_logs.get_chunk('test.log', offset=1, length=2)
+        self.assertEqual(chunk, b'in')
+
+    def test_get_chunk_offset_within_char(self):
+        self.do_chunk_offset_within_char_test('test.log')
+        self.do_chunk_offset_within_char_test('test_compressed.log')
+
+    def do_chunk_offset_within_char_test(self, log_name):
+        task_logs = self.task_logs()
+        offset = self.log_content.index('\n') + 1
+        expected_chunk = b'Line 2 ☺'
+        byteslen = len(expected_chunk)
+
+        # ☺ character requires three bytes to encode; see what happens if we try to read
+        # within that char
+
+        full_chunk = task_logs.get_chunk(log_name, offset=offset, length=byteslen)
+        chunk_min1 = task_logs.get_chunk(log_name, offset=offset, length=byteslen-1)
+        chunk_min2 = task_logs.get_chunk(log_name, offset=offset, length=byteslen-2)
+        chunk_min3 = task_logs.get_chunk(log_name, offset=offset, length=byteslen-3)
+
+        # reading entirety of character should be fine
+        self.assertEqual(full_chunk, expected_chunk)
+
+        # reading prior to character should be fine
+        self.assertEqual(chunk_min3, b'Line 2 ')
+
+        # these two requests to read within the character should have truncated and
+        # given the same result as reading prior to the character
+        self.assertEqual(chunk_min1, chunk_min3)
+        self.assertEqual(chunk_min2, chunk_min3)
+
+
+
+if __name__ == '__main__':
+    TestRunner = get_runner(django.conf.settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests([__name__])
+    sys.exit(bool(failures))

--- a/tests/test_utf8_chunk.py
+++ b/tests/test_utf8_chunk.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from kobo.hub.models import _utf8_chunk as utf8_chunk
+
+class TestUtf8Chunk(unittest.TestCase):
+    def test_noop_ascii(self):
+        """utf8_chunk returns input bytes if byte sequence is entirely ASCII"""
+        bytestr = b'hello world'
+        self.assertIs(utf8_chunk(bytestr), bytestr)
+
+    def test_noop_utf8_end(self):
+        """utf8_chunk returns input bytes if byte sequence uses non-ASCII
+        UTF-8 at the end of the string and is well-formed"""
+        unistr = u'hello 世界'
+        bytestr = unistr.encode('utf-8')
+        self.assertIs(utf8_chunk(bytestr), bytestr)
+
+    def test_noop_utf8_mid(self):
+        """utf8_chunk returns input bytes if byte sequence uses non-ASCII
+        UTF-8 in the middle of the string and is well-formed"""
+        unistr = u'hello 世界!'
+        bytestr = unistr.encode('utf-8')
+        self.assertIs(utf8_chunk(bytestr), bytestr)
+
+    def test_noop_invalid(self):
+        """utf8_chunk returns input bytes if byte sequence is not valid
+        UTF-8 and can't be fixed by truncation"""
+        bytestr = b'hello \xff\xff\xff'
+        self.assertIs(utf8_chunk(bytestr), bytestr)
+
+    def test_fixup_end(self):
+        """utf8_chunk returns copy of input aligned to nearest character boundary
+        if input is a byte sequence truncated in the middle of a unicode character."""
+        unistr = u'hello 世界'
+        bytestr = unistr.encode('utf-8')
+
+        # this is now a broken sequence since we cut it off
+        # partway through a character
+        bytestr = bytestr[:-1]
+
+        # proving it's broken
+        try_decode = lambda: bytestr.decode('utf-8')
+        self.assertRaises(UnicodeDecodeError, try_decode)
+
+        # utf8_chunk unbreaks it by removing until the previous
+        # complete character
+        self.assertEqual(utf8_chunk(bytestr).decode('utf-8'), u'hello 世')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_view_log.py
+++ b/tests/test_view_log.py
@@ -182,7 +182,13 @@ class TestViewLog(django.test.TestCase):
 
         content = response.content
         self.assertTrue(content.startswith('<!DOCTYPE html'))
-        # TODO: when log trimming is added, verify it here
+
+        # Should not have returned whole content
+        self.assertTrue(len(content) < len(self.big_log_content))
+
+        # Should tell the user that the response was trimmed, and should have trimmed
+        # at a line boundary
+        self.assertTrue('&lt;...trimmed, download required for full log&gt;\njoin' in content)
 
     @profile
     def test_view_big_html_wrapped_with_offset(self):
@@ -193,6 +199,8 @@ class TestViewLog(django.test.TestCase):
         content = response.content
         self.assertTrue(content.startswith('<!DOCTYPE html'))
         self.assertTrue(big_log_content()[-2000:] in content)
+
+        self.assertTrue('...trimmed, download required for full log' not in content)
 
     @profile
     def test_view_big_raw(self):

--- a/tests/test_view_log.py
+++ b/tests/test_view_log.py
@@ -254,6 +254,7 @@ class TestViewLog(django.test.TestCase):
             'content': expected_content,
             'new_offset': len(expected_content),
             'task_finished': 0,
+            'next_poll': 5000,
         })
 
     def test_view_small_json(self):
@@ -271,6 +272,7 @@ class TestViewLog(django.test.TestCase):
             'content': expected_content,
             'new_offset': len(expected_content),
             'task_finished': 0,
+            'next_poll': 5000,
         })
 
     def test_view_small_json_offset(self):
@@ -292,6 +294,7 @@ class TestViewLog(django.test.TestCase):
             'content': expected_content,
             'new_offset': offset + len(expected_content),
             'task_finished': 0,
+            'next_poll': 5000,
         })
 
     @profile

--- a/tests/test_view_log.py
+++ b/tests/test_view_log.py
@@ -185,6 +185,16 @@ class TestViewLog(django.test.TestCase):
         # TODO: when log trimming is added, verify it here
 
     @profile
+    def test_view_big_html_wrapped_with_offset(self):
+        # Just get the last 2000 chars - this should not trigger log trimming
+        offset = len(big_log_content()) - 2000
+        response = self.get_log('big.log', data={'offset': offset})
+
+        content = response.content
+        self.assertTrue(content.startswith('<!DOCTYPE html'))
+        self.assertTrue(big_log_content()[-2000:] in content)
+
+    @profile
     def test_view_big_raw(self):
         big_content = self.big_log_content
         offset = 0


### PR DESCRIPTION
The endpoints for viewing log files would previously assume it was safe to
render the entire log file in a single chunk.  Requests for a log would require
O(N) memory allocation from httpd/python, where N is the log size in bytes.

That would sometimes cause memory exhaustion on our system, which
has log files measured in hundreds of MB.

Fix it by applying a limit to some methods of viewing the logs.

- The HTML log view will only show up to a certain limit before truncating.
- The LogWatcher JS now downloads log data in chunks with a size limit.
- Raw log download works as before, has no memory issues as the request
  is properly streamed.

Includes tests using memory_profiler, which may be used to confirm the
decreased memory usage.