### PR TITLE
Improve python 2.6 compatibility, portability of tests

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -23,7 +23,13 @@ def run_test(test_with_args):
     print "Executing tests in %-40s" % test_with_args[0]
     retcode, output = run(['python'] + test_with_args, can_fail=True)
     if retcode == 0:
-        print "[   OK   ]"
+        # If tests were skipped, give caller a hint that this happened.
+        # Summary line example:
+        # "OK (skipped=9)"
+        if 'skipped=' in output.splitlines()[-1]:
+            print "[  SKIP  ]"
+        else:
+            print "[   OK   ]"
         return True
     else:
         print "[ FAILED ]"

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -3,7 +3,7 @@
 
 from __future__ import print_function
 
-import unittest
+import unittest2 as unittest
 import tempfile
 import shutil
 import os

--- a/tests/test_pkgset.py
+++ b/tests/test_pkgset.py
@@ -2,20 +2,27 @@
 # -*- coding: utf-8 -*-
 
 
-import unittest
+import unittest2 as unittest
 import run_tests # set sys.path
 
 import os
+import warnings
 import tempfile
 import shutil
 import hashlib
 import cPickle as pickle
-import rpm
-import warnings
 
-from kobo.pkgset import *
+# tolerate and skip in absence of rpm since it's not installable to virtualenv
+try:
+    import rpm
+except ImportError:
+    HAVE_RPM = False
+else:
+    from kobo.pkgset import *
+    HAVE_RPM = True
 
 
+@unittest.skipUnless(HAVE_RPM, "rpm python module is not installed")
 class TestFileWrapperClass(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp()
@@ -53,6 +60,7 @@ class TestFileWrapperClass(unittest.TestCase):
         print wrap2.file_path
 
 
+@unittest.skipUnless(HAVE_RPM, "rpm python module is not installed")
 class TestRpmWrapperClass(unittest.TestCase):
     def setUp(self):
         self.file_path = "data/dummy-basesystem-10.0-6.noarch.rpm"
@@ -88,6 +96,7 @@ class TestRpmWrapperClass(unittest.TestCase):
         self.assertEqual(wrap.name, wrap2.name)
 
 
+@unittest.skipUnless(HAVE_RPM, "rpm python module is not installed")
 class TestSimpleRpmWrapperClass(unittest.TestCase):
     def setUp(self):
         self.file_path = "data/dummy-basesystem-10.0-6.noarch.rpm"
@@ -110,6 +119,7 @@ class TestSimpleRpmWrapperClass(unittest.TestCase):
         self.assertEqual(wrap.name, wrap2.name)
 
 
+@unittest.skipUnless(HAVE_RPM, "rpm python module is not installed")
 class TestFileCacheClass(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp()

--- a/tests/test_rpmlib.py
+++ b/tests/test_rpmlib.py
@@ -2,12 +2,20 @@
 # -*- coding: utf-8 -*-
 
 
-import unittest
+import unittest2 as unittest
 import run_tests # set sys.path
 
-from kobo.rpmlib import *
+# tolerate and skip in absence of rpm since it's not installable to virtualenv
+try:
+    import rpm
+except ImportError:
+    HAVE_RPM = False
+else:
+    HAVE_RPM = True
+    from kobo.rpmlib import *
 
 
+@unittest.skipUnless(HAVE_RPM, "rpm python module is not installed")
 class TestNVR(unittest.TestCase):
     def test_valid_nvr(self):
         self.assertEqual(parse_nvr("net-snmp-5.3.2.2-5.el5"), dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch=""))

--- a/tests/test_utf8_chunk.py
+++ b/tests/test_utf8_chunk.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import unittest
+import unittest2 as unittest
 from kobo.hub.models import _utf8_chunk as utf8_chunk
 
 class TestUtf8Chunk(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ basepython =
 deps =
 	django16: Django==1.6.11
 	django18: Django==1.8.18
+	unittest2==1.1.0
 
 # Because we depend on some things not available from pypi
 sitepackages = True


### PR DESCRIPTION
A few tests used unittest features introduced in Python >= 2.7.
Use unittest2 module from pypi to get these features also in Python 2.6.

Two tests require rpm and koji modules to be installed, but the upstream
projects for these do not package them as python eggs or ship them to
pypi, making them impractical to install into a virtualenv.  That means
there's a high chance the modules won't be available; in that case, skip
those tests.

Tweak the test runner script so there's a visual indicator of skipped
tests.

The goal is to make "tox" a likely-to-succeed method of running
autotests for developers, with a low rate of false positives.