### PR TITLE
Fix off-by-one error in view offset

### DIFF
--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -181,7 +181,7 @@ def task_log(request, id, log_name):
 
     context = {
         "title": "Task log",
-        "offset": offset + content_len + 1,
+        "offset": offset + content_len,
         "task_finished": task.is_finished() and 1 or 0,
         "next_poll": None if task.is_finished() else LOG_WATCHER_INTERVAL,
         "content": content,


### PR DESCRIPTION
Several times I've loaded the log of a task in progress in the
browser and saw a line with an omitted leading character like:

  2017-08-29 00:55:40 [INFO    ] Publishing ...
  2017-08-29 00:55:42 [DEBUG   ] Waiting on the following tasks ...
  017-08-29 00:55:45 [DEBUG   ] Task successful: ef2ce68d-d3e4-4e36-b78c-c19e3b6b9146, ...

It turns out there's a trivial bug in setting the offset variable
when rendering the HTML view (and the variable influences the
LogWatcher).  offset is zero-indexed and it does not make sense to add 1
here.

This caused the first character added to logs since the page was loaded
to always be skipped by the Logwatcher JS.

(This commit doesn't add an autotest for this, but some other bugfixes
in the same area are going to incidentally cover this with tests.)