### PR TITLE
Fix log trim calculation for compressed logs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
 	django16: Django==1.6.11
 	django18: Django==1.8.18
 	unittest2==1.1.0
+	mock==2.0.0
 
 # Because we depend on some things not available from pypi
 sitepackages = True


### PR DESCRIPTION
Usage of the content_len variable didn't make sense here.  That's
calculated based on the actual file size.  In the compressed case,
that's different from the size of the log's content in bytes, so doesn't
make sense to use it to decide whether log content is being trimmed.

Fixes two problems:

- wrong offset value was passed to HTML template which would cause
  LogWatcher to start loading logs at a wrong offset

- the "log was trimmed" message was sometimes added where it wasn't
  necessary

Noticed during manual testing of a tiny log file where compressed size
is larger than uncompressed, so added a testcase for that scenario.