### PR TITLE
six is a runtime requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,5 @@ setup(
     packages        = packages,
     package_data    = package_data,
     scripts         = ["kobo/admin/kobo-admin"],
+    install_requires=["six"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
 	django18: Django==1.8.18
 	unittest2==1.1.0
 	mock==2.0.0
-    six
 
 # Because we depend on some things not available from pypi
 sitepackages = True


### PR DESCRIPTION
Prior to this change, `pip install kobo` would not install `six`. This is a problem because we depend on six in a number of locations at runtime. For example `import kobo.rpmlib` would fail because nothing pulled in six.

The Tox tests were passing because Tox installed six as part of the test operation (`tox.ini`).

Move the `six` package from `tox.ini` to the setuptools packaging so all
kobo users will install `six`.