### PR TITLE
Limit dashes in log files

### DIFF
--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -290,7 +290,10 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
     try:
 
         if show_cmd:
-            command = "COMMAND: %s\n%s\n" % (cmd, "-" * (len(cmd) + 9))
+            command = "COMMAND: %s\n%s\n" % (
+                cmd,
+                "-" * min(len(cmd) + 9, 79)
+            )
             if stdout:
                 print(command, end='')
             if logfile:


### PR DESCRIPTION
When the command is echoed in the log file, it has an underline of dashes, that matches the length of the command. This is nice as a delimiter, but for very long commands it can be a little annoying. Let's limit the maximum length to 79, which should fit on a reasonably sized terminal without wrapping.