### PR TITLE
task_url: make https:// prefix detection work properly

### DIFF
--- a/kobo/hub/xmlrpc/client.py
+++ b/kobo/hub/xmlrpc/client.py
@@ -136,7 +136,10 @@ def task_url(request, task_id):
     @return: task URL
     @rtype:  str
     """
-    prefix = request.META["SERVER_PORT"] == 443 and "https://" or "http://"
+    if str(request.META["SERVER_PORT"]) == "443":
+        prefix = "https://"
+    else:
+        prefix = "http://"
 
     # use HTTP_HOST (address can point to a virtual host)
     # if address points to localhost, use SERVER_NAME in order to make link globally valid


### PR DESCRIPTION
```
If request.META["SERVER_PORT"] is a string, it never matches the 443
number, which results in using the http:// prefix in all cases.
Comparison of strings works better in this case.

Tested with: python-2.6.6-66.el6_8
```
