### PR TITLE
Remove unused imports.

### DIFF
--- a/kobo/admin/__init__.py
+++ b/kobo/admin/__init__.py
@@ -8,7 +8,6 @@ import sys
 import shutil
 
 import kobo.cli
-from kobo.types import Enum, EnumItem
 
 import kobo.admin.commands
 

--- a/kobo/cli.py
+++ b/kobo/cli.py
@@ -71,7 +71,6 @@ import sys
 import optparse
 import datetime
 from optparse import Option
-from six.moves.xmlrpc_client import Fault
 
 from kobo.plugins import Plugin, PluginContainer
 from kobo.shortcuts import force_list

--- a/kobo/django/auth/models.py
+++ b/kobo/django/auth/models.py
@@ -1,4 +1,3 @@
-import re
 from django.db import models
 from django.core import validators
 from django.utils.translation import ugettext_lazy as _

--- a/kobo/django/upload/models.py
+++ b/kobo/django/upload/models.py
@@ -5,7 +5,6 @@ import os
 
 from django.conf import settings
 from django.db import models
-from django.contrib.auth.models import User
 
 from kobo.shortcuts import random_string
 from kobo.types import Enum

--- a/kobo/django/xmlrpc/auth.py
+++ b/kobo/django/xmlrpc/auth.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import datetime
 import base64
 import socket
 
@@ -9,7 +8,6 @@ import django.contrib.auth
 from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import PermissionDenied
-from django.contrib.sessions.models import Session
 
 from kobo.django.auth.krb5 import Krb5RemoteUserBackend
 

--- a/kobo/django/xmlrpc/views.py
+++ b/kobo/django/xmlrpc/views.py
@@ -37,7 +37,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 from django.template import Template, RequestContext, loader
-from django.views.decorators.csrf import csrf_exempt
 
 from kobo.django.xmlrpc.dispatcher import DjangoXMLRPCDispatcher
 

--- a/kobo/hub/decorators.py
+++ b/kobo/hub/decorators.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-import socket
-
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
-from kobo.decorators import decorator_with_args
 from kobo.django.xmlrpc.decorators import *
 
 

--- a/kobo/hub/xmlrpc/auth.py
+++ b/kobo/hub/xmlrpc/auth.py
@@ -1,15 +1,7 @@
 # -*- coding: utf-8 -*-
 
-
-import datetime
-import base64
-import socket
-
 import django.contrib.auth
-from django.conf import settings
-from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import PermissionDenied
-from django.contrib.sessions.models import Session
 
 from kobo.hub.models import Worker
 from kobo.django.auth.krb5 import Krb5RemoteUserBackend


### PR DESCRIPTION
If this patch gets accepted I will continue to work on code cleanup, there are many places to make improvements. Running *pyflakes* or *pylint* against the code outputs a lot of warnings and errors.

Next, I plan to remove all `from module import *`.
