### PR TITLE
tests: Unit tests for TaskManager

### DIFF
--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -257,6 +257,7 @@ class Worker(models.Model):
         """
         if (self.enabled, self.ready, self.task_count) != (enabled, ready, task_count):
             self.save()
+
         return self.export()
 
 

--- a/kobo/hub/xmlrpc/worker.py
+++ b/kobo/hub/xmlrpc/worker.py
@@ -4,6 +4,8 @@
 import os
 import random
 
+from operator import itemgetter
+
 from kobo.client.constants import TASK_STATES
 from kobo.hub.models import Task
 from kobo.hub.decorators import validate_worker
@@ -217,7 +219,7 @@ def get_tasks_to_assign(request):
     # It could also help to lower task assignment conflicts.
     # After that, sort it by priority again.
     random.shuffle(tasks)
-    tasks.sort(lambda x, y: cmp(x["priority"], y["priority"]), reverse=True)
+    tasks.sort(key=itemgetter("priority"), reverse=True)
     task_list.extend(tasks[:max_tasks])
 
     return task_list
@@ -227,7 +229,7 @@ def get_tasks_to_assign(request):
 def get_awaited_tasks(request, awaited_task_list):
     task_list = []
     for task in Task.objects.filter(awaited=True, parent__in=[ i["id"] for i in awaited_task_list ]):#.order_by("-exclusive", "-awaited", "id")[:50]:
-        task_info = task.export()
+        task_info = task.export(False)
         task_list.append(task_info)
     return task_list
 

--- a/kobo/worker/taskmanager.py
+++ b/kobo/worker/taskmanager.py
@@ -207,7 +207,8 @@ class TaskManager(kobo.log.LoggingBase):
                 self.log_error("%s" % ex)
 
         self.log_debug("pids: %s" % list(self.pid_dict.values()))
-        for task_id in self.pid_dict.keys():
+
+        for task_id in list(self.pid_dict.keys()):
             if self.is_finished_task(task_id):
                 self.log_info("Task has finished: %s" % task_id)
                 finished_tasks.add(task_id)
@@ -217,7 +218,7 @@ class TaskManager(kobo.log.LoggingBase):
                 if task_id in self.task_dict:
                     del self.task_dict[task_id]
 
-        for task_id, pid in self.pid_dict.items():
+        for task_id, pid in list(self.pid_dict.items()):
             if task_id not in self.task_dict:
                 # expected to happen when:
                 #  - we are in the narrow gap between the time the task records its result
@@ -420,8 +421,9 @@ class TaskManager(kobo.log.LoggingBase):
             hub.upload_task_log(StringIO(message), task.task_id, "error.log")
             hub.upload_task_log(StringIO(kobo.tback.Traceback().get_traceback()), task.task_id, "traceback.log", mode=0o600)
             failed = True
+        finally:
+            thread.stop()
 
-        thread.stop()
         if failed:
             hub.worker.fail_task(task.task_id, task.result)
         else:

--- a/tests/rpc.py
+++ b/tests/rpc.py
@@ -1,0 +1,106 @@
+from mock import Mock, PropertyMock
+
+from kobo.hub.xmlrpc import worker
+from kobo.xmlrpc import encode_xmlrpc_chunks_iterator
+
+
+class _RequestMock(object):
+
+    def __init__(self, worker_instance):
+        self.worker = worker_instance
+        self.user = Mock()
+        self.user.is_authenticated.return_value = True
+        type(self.user).username = PropertyMock(return_value='mockuser')
+
+
+class RpcServiceMock(object):
+    '''
+    RpcServiceMock implements all XML-RPC methods.
+    '''
+
+    def __init__(self, worker_instance):
+        self.worker = worker_instance
+        self._request = _RequestMock(worker_instance)
+
+    def get_worker_info(self):
+        return worker.get_worker_info(self._request)
+
+    def get_worker_id(self):
+        return worker.get_worker_id(self._request)
+
+    def get_worker_tasks(self):
+        return worker.get_worker_tasks(self._request)
+
+    def get_task(self, task_id):
+        return worker.get_task(self._request, task_id)
+
+    def get_task_no_verify(self, task_id):
+        return worker.get_task_no_verify(self._request, task_id)
+
+    def interrupt_tasks(self, task_list):
+        return worker.interrupt_tasks(self._request, task_list)
+
+    def timeout_tasks(self, task_list):
+        return worker.timeout_tasks(self._request, task_list)
+
+    def assign_task(self, task_id):
+        return worker.assign_task(self._request, task_id)
+
+    def open_task(self, task_id):
+        return worker.open_task(self._request, task_id)
+
+    def close_task(self, task_id, task_result):
+        return worker.close_task(self._request, task_id, task_result)
+
+    def cancel_task(self, task_id):
+        return worker.cancel_task(self._request, task_id)
+
+    def fail_task(self, task_id, task_result):
+        return worker.fail_task(self._request, task_id, task_result)
+
+    def set_task_weight(self, task_id, weight):
+        return worker.set_task_weight(self._request, task_id, weight)
+
+    def update_worker(self, enabled, ready, task_count):
+        return worker.update_worker(self._request, enabled, ready, task_count)
+
+    def get_tasks_to_assign(self):
+        return worker.get_tasks_to_assign(self._request, )
+
+    def get_awaited_tasks(self, awaited_task_list):
+        return worker.get_awaited_tasks(self._request, awaited_task_list)
+
+    def create_subtask(self, label, method, args, parent_id):
+        return worker.create_subtask(self._request, label, method, args, parent_id)
+
+    def wait(self, task_id, child_list=None):
+        return worker.wait(self._request, task_id, child_list)
+
+    def check_wait(self, task_id, child_list=None):
+        return worker.check_wait(self._request, task_id, child_list)
+
+    def upload_task_log(self, task_id, relative_path, mode, chunk_start,
+                        chunk_len, chunk_checksum, encoded_chunk):
+        return worker.upload_task_log(self._request, task_id, relative_path, mode, chunk_start,
+                                      chunk_len, chunk_checksum, encoded_chunk)
+
+
+class HubProxyMock(object):
+    ''' Mock for kobo.client.HubProxy '''
+
+    def __init__(self, conf, **kwargs):
+        if 'worker' in kwargs:
+            self.worker = kwargs.get('worker')
+        else:
+            self.worker = conf.get('worker')
+
+        if self.worker is None:
+            raise Exception('Missing worker argument')
+
+    def upload_file(self, file_name, target_dir):
+        # TODO: This should be implemented as in the original class.
+        pass
+
+    def upload_task_log(self, file_obj, task_id, remote_file_name, append=True, mode=0o644):
+        # TODO: This should be implemented as in the original class.
+        pass

--- a/tests/test_taskmanager.py
+++ b/tests/test_taskmanager.py
@@ -1,0 +1,968 @@
+# -*- coding: utf-8 -*-
+
+import errno
+import os
+import signal
+
+import django
+import pytest
+import six
+
+# Only for Django >= 1.7
+if 'setup' in dir(django):
+    # This has to happen before below imports because they have a hard requirement
+    # on settings being loaded before import.
+    django.setup()
+
+from datetime import datetime, timedelta
+
+from django.contrib.auth.models import User
+
+from mock import Mock, PropertyMock, patch
+
+from kobo.client.constants import TASK_STATES
+from kobo.exceptions import ShutdownException
+from kobo.hub.models import Arch, Channel, Task, Worker
+from kobo.worker import TaskBase
+from kobo.worker.task import FailTaskException
+from kobo.worker.taskmanager import TaskManager, TaskContainer
+from six.moves.xmlrpc_client import ProtocolError
+
+from .rpc import HubProxyMock, RpcServiceMock
+from .utils import DjangoRunner
+
+runner = DjangoRunner()
+setup_module = runner.start
+teardown_module = runner.stop
+
+
+class DummyTask(TaskBase):
+
+    def run(self):
+        self.result = True
+
+    @classmethod
+    def cleanup(cls, hub, conf, task_info):
+        pass
+
+    @classmethod
+    def notification(cls, hub, conf, task_info):
+        pass
+
+
+class DummyForegroundTask(DummyTask):
+    enabled = True
+    arches = ['testarch']
+    channels = ['testchannel']
+    exclusive = False
+    foreground = True
+    priority = 10
+    weight = 1.0
+
+
+class DummyForkTask(DummyTask):
+    enabled = True
+    arches = ['testarch']
+    channels = ['testchannel']
+    exclusive = False
+    foreground = False
+    priority = 10
+    weight = 1.0
+
+
+class DummyHeavyTask(DummyTask):
+    enabled = True
+    arches = ['testarch']
+    channels = ['testchannel']
+    exclusive = False
+    foreground = False
+    priority = 10
+    weight = 100.0
+
+
+class DummyFailTask(DummyTask):
+    enabled = True
+    arches = ['testarch']
+    channels = ['testchannel']
+    exclusive = False
+    foreground = True
+    priority = 10
+    weight = 1.0
+
+    def run(self):
+        raise FailTaskException()
+
+
+class DummyExceptionTask(DummyTask):
+    enabled = True
+    arches = ['testarch']
+    channels = ['testchannel']
+    exclusive = False
+    foreground = True
+    priority = 10
+    weight = 1.0
+
+    def run(self):
+        raise Exception()
+
+
+class TestTaskManager(django.test.TestCase):
+
+    def setUp(self):
+        super(TestTaskManager, self).setUp()
+
+        TaskContainer.register_plugin(DummyForegroundTask)
+        TaskContainer.register_plugin(DummyForkTask)
+        TaskContainer.register_plugin(DummyHeavyTask)
+        TaskContainer.register_plugin(DummyFailTask)
+        TaskContainer.register_plugin(DummyExceptionTask)
+
+        user = User.objects.create(username='testuser')
+        arch = Arch.objects.create(name='testarch')
+        channel = Channel.objects.create(name='testchannel')
+
+        w = Worker.objects.create(
+            worker_key='mock-worker',
+            name='mock-worker',
+        )
+
+        w.arches.add(arch)
+        w.channels.add(channel)
+        w.save()
+
+        self._arch = arch
+        self._channel = channel
+        self._user = user
+        self._worker = RpcServiceMock(w)
+
+    @pytest.mark.xfail(reason='Check issue #68 for more info (https://git.io/fxSZ2).')
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_update_worker_info(self):
+        tm = TaskManager(conf={'worker': self._worker})
+        self.assertTrue(tm.worker_info['enabled'])
+        self.assertTrue(tm.worker_info['ready'])
+
+        tm.worker_info['enabled'] = False
+        tm.worker_info['ready'] = False
+        tm.update_worker_info()
+        self.assertFalse(tm.worker_info['enabled'])
+        self.assertFalse(tm.worker_info['ready'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_update_worker_info_catch_protocol_error(self):
+        tm = TaskManager(conf={'worker': self._worker})
+
+        tm.hub.worker.update_worker = Mock(side_effect=ProtocolError(None, None, None, None))
+        tm.update_worker_info()
+
+        with self.assertRaises(ValueError):
+            tm.hub.worker.update_worker = Mock(side_effect=ValueError)
+            tm.update_worker_info()
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_wakeup_task_if_alert_is_set(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        tm = TaskManager(conf={'worker': self._worker})
+
+        task_info = t.export(False)
+        task_info['alert'] = True
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+            tm.wakeup_task(task_info)
+            os_mock.kill.assert_called_once_with(9999, signal.SIGUSR2)
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_wakeup_task_if_alert_is_not_set(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+            tm.wakeup_task(task_info)
+            os_mock.kill.assert_not_called()
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_wakeup_task_catch_os_error(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        tm = TaskManager(conf={'worker': self._worker})
+
+        task_info = t.export(False)
+        task_info['alert'] = True
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+
+        with patch('kobo.worker.taskmanager.os', kill=Mock(side_effect=OSError)) as os_mock:
+            tm.wakeup_task(task_info)
+            os_mock.kill.assert_called_once_with(9999, signal.SIGUSR2)
+
+        with self.assertRaises(ValueError):
+            with patch('kobo.worker.taskmanager.os', kill=Mock(side_effect=ValueError)) as os_mock:
+                tm.wakeup_task(task_info)
+                os_mock.kill.assert_called_once_with(9999, signal.SIGUSR2)
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_update_tasks_timeout_task_if_running_for_to_long(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            timeout=-1, # task will always timeout with negative value
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        self.assertTrue(t.id in tm.pid_dict)
+        tm.update_tasks()
+        self.assertFalse(t.id in tm.pid_dict)
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['TIMEOUT'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_update_tasks_finish_task_if_canceled(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        self._worker.cancel_task(t.id)
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CANCELED'])
+
+        self.assertTrue(t.id in tm.pid_dict)
+        tm.update_tasks()
+        self.assertFalse(t.id in tm.pid_dict)
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CANCELED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_update_tasks_interrupt_taks_if_not_on_pid_list(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['OPEN'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+
+        self.assertFalse(t.id in tm.pid_dict)
+        tm.update_tasks()
+        self.assertFalse(t.id in tm.pid_dict)
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['INTERRUPTED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_update_tasks_cleanup_finished_tasks(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        tm.run_task(task_info)
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CLOSED'])
+
+        with patch('kobo.worker.taskmanager.os', waitpid=Mock(return_value=(123, 0))) as os_mock:
+            self.assertTrue(t.id in tm.pid_dict)
+            tm.update_tasks()
+            self.assertFalse(t.id in tm.pid_dict)
+            os_mock.waitpid.assert_called_once()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CLOSED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_update_tasks_without_tasks(self):
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.update_tasks()
+        self.assertEqual(len(tm.pid_dict.keys()), 0)
+        self.assertEqual(len(tm.task_dict.keys()), 0)
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_get_next_task_runs_free_task(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.get_next_task()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CLOSED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_get_next_task_dont_run_tasks_if_disabled(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.worker_info['enabled'] = False
+
+        tm.get_next_task()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_get_next_task_dont_run_tasks_if_not_ready(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.worker_info['ready'] = False
+
+        tm.get_next_task()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_get_next_task_raise_shutdown_exception_if_locked_and_no_tasks_running(self):
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.lock()
+
+        # ensure no tasks are running
+        self.assertEqual(len(self._worker.worker.running_tasks()), 0)
+
+        with self.assertRaises(ShutdownException):
+            tm.get_next_task()
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_get_next_task_runs_assigened_awaited_task_if_locked(self):
+        t1 = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['OPEN'],
+        )
+
+        t2 = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['ASSIGNED'],
+            awaited=True,
+            parent=t1,
+        )
+
+        t3 = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            waiting=True,
+            parent=t2,
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t1.state, TASK_STATES['OPEN'])
+        self.assertEqual(t2.state, TASK_STATES['ASSIGNED'])
+        self.assertEqual(t3.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.lock()
+        tm.get_next_task()
+
+        # reload task info
+        t1 = Task.objects.get(id=t1.id)
+        self.assertEqual(t1.state, TASK_STATES['OPEN'])
+
+        t2 = Task.objects.get(id=t2.id)
+        self.assertEqual(t2.state, TASK_STATES['CLOSED'])
+
+        t3 = Task.objects.get(id=t3.id)
+        self.assertEqual(t3.state, TASK_STATES['FREE'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_take_task_open_task_if_free(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_take_task_open_task_if_assigned(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['ASSIGNED'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['ASSIGNED'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_take_task_runs_task_if_foreground(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            os_mock.devnull = os.devnull
+
+            tm.take_task(task_info)
+            os_mock.fork.assert_not_called()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CLOSED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_take_task_catch_errors_if_cant_open_task(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.hub.worker.open_task = Mock(side_effect=ValueError)
+
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_not_called()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_take_task_if_worker_not_ready(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.worker_info['ready'] = False
+
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_not_called()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_take_task_if_wrong_arch(self):
+        arch = Arch.objects.create(name='arch_x86', pretty_name='Arch x86')
+
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_not_called()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_take_task_if_wrong_channel(self):
+        channel = Channel.objects.create(name='channel_x86')
+
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_not_called()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_take_task_set_load_and_ready(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyHeavyTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        self.assertEqual(tm.worker_info['current_load'], 100)
+        self.assertFalse(tm.worker_info['ready'])
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_fork_task(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.fork_task(task_info)
+            os_mock.fork.assert_called_once()
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_fork_task_runs_task_if_cant_fork(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['OPEN'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=0)) as os_mock:
+            os_mock.devnull = os.devnull
+
+            with patch('kobo.worker.taskmanager.signal') as signal_mock:
+                tm.fork_task(task_info)
+                os_mock.fork.assert_called_once()
+                os_mock.setpgrp.assert_called_once()
+                os_mock._exit.assert_called_once()
+                signal_mock.signal.assert_called()
+
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CLOSED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_run_task_runs_foreground_task(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForegroundTask',
+            state=TASK_STATES['OPEN'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+ 
+        tm.run_task(task_info)
+
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CLOSED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_run_task_runs_fork_task(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['OPEN'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        tm.run_task(task_info)
+
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['CLOSED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_run_task_mark_task_as_failed(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyFailTask',
+            state=TASK_STATES['OPEN'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        tm.run_task(task_info)
+
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['FAILED'])
+
+    @pytest.mark.xfail(six.PY3, reason='Check issue #66 for more info (https://git.io/fxSc6).')
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_run_task_mark_task_as_failed_if_generic_exception(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyExceptionTask',
+            state=TASK_STATES['OPEN'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        tm.run_task(task_info)
+
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['FAILED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_finish_task(self):
+        tm = TaskManager(conf={'worker': self._worker})
+
+        mock = Mock()
+        # inject mock plugin
+        tm.task_container.plugins['Mock'] = mock
+
+        tm.finish_task({
+            'method': 'Mock'
+        })
+
+        mock.cleanup.assert_called_once()
+        mock.notification.assert_called_once()
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_is_finished_task(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        with patch('kobo.worker.taskmanager.os', waitpid=Mock(return_value=(123, 0))) as os_mock:
+            self.assertTrue(tm.is_finished_task(t.id))
+            os_mock.waitpid.assert_called_once()
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_is_finished_task_invalid_child_pid(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        with patch('kobo.worker.taskmanager.os', waitpid=Mock(return_value=(0, 0))) as os_mock:
+            self.assertFalse(tm.is_finished_task(t.id))
+            os_mock.waitpid.assert_called_once()
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_is_finished_task_catch_os_error(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        err = OSError()
+        err.errno = errno.ECHILD
+
+        with patch('kobo.worker.taskmanager.os', waitpid=Mock(side_effect=err)) as os_mock:
+            self.assertFalse(tm.is_finished_task(t.id))
+            os_mock.waitpid.assert_called_once()
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_shutdown_with_running_tasks(self):
+        t = Task.objects.create(
+            worker=self._worker.worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            method='DummyForkTask',
+            state=TASK_STATES['FREE'],
+        )
+
+        self.assertEqual(t.state, TASK_STATES['FREE'])
+
+        tm = TaskManager(conf={'worker': self._worker})
+        task_info = t.export(False)
+
+        with patch('kobo.worker.taskmanager.os', fork=Mock(return_value=9999)) as os_mock:
+            tm.take_task(task_info)
+            os_mock.fork.assert_called_once()
+
+        tm.update_tasks()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['OPEN'])
+
+        tm.shutdown()
+
+        # reload task info
+        t = Task.objects.get(id=t.id)
+        self.assertEqual(t.state, TASK_STATES['INTERRUPTED'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_shutdown_without_running_tasks(self):
+        tm = TaskManager(conf={'worker': self._worker})
+        tm.update_tasks()
+        tm.shutdown()
+
+        self.assertTrue(tm.worker_info['enabled'])
+        self.assertTrue(tm.worker_info['ready'])
+
+    @patch('kobo.worker.taskmanager.HubProxy', HubProxyMock)
+    def test_lock(self):
+        tm = TaskManager(conf={'worker': self._worker})
+        self.assertFalse(tm.locked)
+        tm.lock()
+        self.assertTrue(tm.locked)


### PR DESCRIPTION
@rohanpm as we discussed this is the unit test for TaskManager. There are more tests to be written, but I want feedback before writing more cases.

Few things are mocked, but the test uses the worker as if it is a real RPC service, but without any RPC calls.

To get most of the tests running issue #67 was fixed.