### PR TITLE
Pass on_delete to XmlRpcLog.user explicitly

### DIFF
--- a/kobo/django/xmlrpc/models.py
+++ b/kobo/django/xmlrpc/models.py
@@ -7,7 +7,8 @@ from django.conf import settings
 
 class XmlRpcLog(models.Model):
     dt_inserted = models.DateTimeField(auto_now_add=True)
-    user        = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True)
+    user        = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True,
+                                    on_delete=models.SET_NULL)
     method      = models.CharField(max_length=255)
     args        = models.TextField(blank=True)
 


### PR DESCRIPTION
As Django documentation mentions, on_delete will become a required
argument in Django 2.0.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>