### PR TITLE
Use idna 2.7.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     # On python 2.6, we must install older versions of
     # a few deps explicitly, as the implicitly selected versions
     # won't support 2.6
+    py26: idna==2.7
     py26: pycparser==2.18
     py26: pyOpenSSL==17.5.0
 


### PR DESCRIPTION
idna 2.7 is the last one to support Python 2.6.