### PR TITLE
kobo/xmlrpc.py: make retry_request_decorator() work again

### DIFF
--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -579,7 +579,7 @@ def retry_request_decorator(transport_class):
                     return result
                 except KeyboardInterrupt:
                     raise
-                except (socket.error, socket.herror, socket.gaierror, socket.timeout) as ex:
+                except (socket.error, socket.herror, socket.gaierror, socket.timeout, httplib.CannotSendRequest) as ex:
                     if i >= self.retry_count:
                         raise
                     retries_left = self.retry_count - i


### PR DESCRIPTION
commit 8aa03e6acb53a3d7a47c26cb1266e00f9e59a12b turned the retry code into dead code by mistake.

Additionally, handle `CannotSendRequest` in `retry_request_decorator()`.  It is usually a recoverable error, so it is not necessary to interrupt the worker altogether.  In some cases, this even prevented the worker from uploading the traceback back to the hub.