### PR TITLE
kobo/xmlrpc.py: hold CONNECTION_LOCK while calling make_connection()

### DIFF
--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -535,9 +535,12 @@ class SafeCookieTransport(xmlrpclib.SafeTransport, CookieTransport):
             conn.set_timeout(self.timeout)
             return conn
         else:
+            CONNECTION_LOCK.acquire()
+            self._connection = (None, None) # this disables connection caching which causes a race condition when running in threads
             conn = xmlrpclib.SafeTransport.make_connection(self, host)
             if self.timeout:
                 conn.timeout = self.timeout
+            CONNECTION_LOCK.release()
             return conn
 
     # override the appropriate request method


### PR DESCRIPTION
The same locking code that was used in the CookieTransport class should
be used in the SafeCookieTransport class.  I have no self-contained
reproducer for this bug: Covscan workers occasionally fail to upload
task results to hub over XML-RPC, only if https:// HUB_URL is used
(whereas they work reliably if http:// HUB_URL is used).