### PR TITLE
Log exceptions from run_task

### DIFF
--- a/kobo/worker/taskmanager.py
+++ b/kobo/worker/taskmanager.py
@@ -367,6 +367,9 @@ class TaskManager(kobo.log.LoggingBase):
 
             # run the task
             self.run_task(task_info)
+        except Exception:
+            self.log_critical("Error running forked task", exc_info=1)
+            # don't bother raising since we're about to exit
         finally:
             # die
             os._exit(os.EX_OK)


### PR DESCRIPTION
When a task was run from fork_task, any uncaught exceptions would
be silently discarded (e.g. a communication failure between worker
and hub). This makes debugging more difficult than it should be.

Make sure any raised exception is logged in this block.

Fixes #32