### PR TITLE
Make LoggingThread recover on all errors

### DIFF
--- a/kobo/worker/logger.py
+++ b/kobo/worker/logger.py
@@ -6,7 +6,6 @@ import time
 import six
 
 from six.moves import queue
-from six.moves.xmlrpc_client import Fault
 from six import BytesIO
 
 
@@ -56,7 +55,7 @@ class LoggingThread(threading.Thread):
                 self._hub.upload_task_log(BytesIO(self._send_data), self._task_id, "stdout.log", append=True)
                 self._send_time = now
                 self._send_data = ""
-            except Fault:
+            except Exception:
                 continue
 
     def write(self, data):


### PR DESCRIPTION
Previously, LoggingThread would recover from any XML-RPC fault,
but would stop when any other type of exception was encountered.
That is a problem, as it means the worker will permanently give
up sending messages to the hub when all kinds of temporary
issues occur (e.g. a temporary network disruption between worker
and hub). The task underneath may continue running for hours,
with all log messages being discarded.

Given the nature of this thread, it makes more sense to attempt
recovering from *all* kinds of errors, as we should try hard not
to lose log messages from a task.

Fixes #60