### PR TITLE
Fix LoggingThread for python3

### DIFF
--- a/kobo/worker/logger.py
+++ b/kobo/worker/logger.py
@@ -5,8 +5,9 @@ import time
 
 import six
 
-from six.moves import StringIO, queue
+from six.moves import queue
 from six.moves.xmlrpc_client import Fault
+from six import BytesIO
 
 
 __all__ = (
@@ -52,7 +53,7 @@ class LoggingThread(threading.Thread):
                 self._send_data = self._send_data.encode('utf-8')
 
             try:
-                self._hub.upload_task_log(StringIO(self._send_data), self._task_id, "stdout.log", append=True)
+                self._hub.upload_task_log(BytesIO(self._send_data), self._task_id, "stdout.log", append=True)
                 self._send_time = now
                 self._send_data = ""
             except Fault:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -2,12 +2,11 @@
 
 import time
 
-import six
 import unittest2 as unittest
-import pytest
+
+from six import BytesIO
 
 from mock import Mock
-from six.moves import StringIO
 
 from kobo.worker.logger import LoggingThread, LoggingIO
 from .utils import ArgumentIsInstanceOf
@@ -15,7 +14,6 @@ from .utils import ArgumentIsInstanceOf
 
 class TestLoggingThread(unittest.TestCase):
 
-    @pytest.mark.xfail(six.PY3, reason='Check issue #66 for more info (https://git.io/fxSc6).')
     def test_upload_task_log_on_stop(self):
         mock_hub = Mock()
         thread = LoggingThread(mock_hub, 9999)
@@ -31,9 +29,8 @@ class TestLoggingThread(unittest.TestCase):
         thread.stop()
         self.assertFalse(thread.is_alive())
         self.assertFalse(thread._running)
-        mock_hub.upload_task_log.assert_called_once_with(ArgumentIsInstanceOf(StringIO), 9999, 'stdout.log', append=True)
+        mock_hub.upload_task_log.assert_called_once_with(ArgumentIsInstanceOf(BytesIO), 9999, 'stdout.log', append=True)
 
-    @pytest.mark.xfail(six.PY3, reason='Check issue #66 for more info (https://git.io/fxSc6).')
     def test_upload_task_log_after_some_time(self):
         mock_hub = Mock()
         thread = LoggingThread(mock_hub, 9999)
@@ -50,7 +47,7 @@ class TestLoggingThread(unittest.TestCase):
 
         # let the thread running for a while
         time.sleep(.1)
-        mock_hub.upload_task_log.assert_called_once_with(ArgumentIsInstanceOf(StringIO), 9999, 'stdout.log', append=True)
+        mock_hub.upload_task_log.assert_called_once_with(ArgumentIsInstanceOf(BytesIO), 9999, 'stdout.log', append=True)
 
         thread.stop()
         self.assertFalse(thread.is_alive())


### PR DESCRIPTION
Looking at the implementation of upload_task_log, it expects to
receive bytes as input, not text. Hence, the appropriate file-like
object is BytesIO, not StringIO.

Fixes #66