### PR TITLE
Django 1.11 compatibility improvments.

### DIFF
--- a/kobo/django/auth/krb5.py
+++ b/kobo/django/auth/krb5.py
@@ -18,13 +18,13 @@ AUTHENTICATION_BACKENDS = (
 
 # Add login and logout adresses to urls.py:
 
-urlpatterns = patterns("",
+urlpatterns = [
     ...
     url(r'^auth/krb5login/$',
     django.views.generic.TemplateView.as_view(template = 'auth/krb5login.html'),
     url(r'^auth/logout/$', 'django.contrib.auth.views.logout', kwargs={"next_page": "/"}),
     ...
-)
+]
 
 
 # Set a httpd config to protect krb5login page with kerberos.

--- a/kobo/django/upload/urls.py
+++ b/kobo/django/upload/urls.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls.defaults import url
 
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^$", "kobo.django.upload.views.file_upload"),
-)
+]

--- a/kobo/hub/urls/arch.py
+++ b/kobo/hub/urls/arch.py
@@ -2,12 +2,12 @@
 
 
 from django.utils.translation import ugettext_lazy as _
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from kobo.django.views.generic import ExtraListView
 from kobo.hub.views import ArchDetailView
 from kobo.hub.models import Arch
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^$", ExtraListView.as_view(
         queryset=Arch.objects.order_by("name"),
         template_name="arch/list.html",
@@ -15,4 +15,4 @@ urlpatterns = patterns("",
         title=_("Architectures"),
     ), name="arch/list"),
     url(r"^(?P<pk>\d+)/$", ArchDetailView.as_view(), name="arch/detail"),
-)
+]

--- a/kobo/hub/urls/auth.py
+++ b/kobo/hub/urls/auth.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^login/$", "kobo.hub.views.login", name="auth/login"),
     url(r"^krb5login/$", "kobo.hub.views.krb5login", name="auth/krb5login"),
     url(r'^logout/$', 'kobo.hub.views.logout', name="auth/logout"),
-)
+]

--- a/kobo/hub/urls/channel.py
+++ b/kobo/hub/urls/channel.py
@@ -2,12 +2,12 @@
 
 
 from django.utils.translation import ugettext_lazy as _
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from kobo.django.views.generic import ExtraListView
 from kobo.hub.views import DetailViewWithWorkers
 from kobo.hub.models import Channel
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^$", ExtraListView.as_view(
         queryset=Channel.objects.order_by("name"),
         template_name="channel/list.html",
@@ -20,4 +20,4 @@ urlpatterns = patterns("",
         context_object_name = "channel",
         title = _("Architecture detail"),
     ), name="channel/detail"),
-)
+]

--- a/kobo/hub/urls/task.py
+++ b/kobo/hub/urls/task.py
@@ -2,16 +2,16 @@
 
 
 from django.utils.translation import ugettext_lazy as _
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from kobo.hub.models import TASK_STATES
 from kobo.hub.views import TaskListView, TaskDetail
 
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^$", TaskListView.as_view(), name="task/index"),
     url(r"^(?P<pk>\d+)/$", TaskDetail.as_view(), name="task/detail"),
     url(r"^running/$", TaskListView.as_view(state=(TASK_STATES["FREE"], TASK_STATES["ASSIGNED"], TASK_STATES["OPEN"]), title=_("Running tasks"), order_by=["id"]), name="task/running"),
     url(r"^finished/$", TaskListView.as_view(state=(TASK_STATES["CLOSED"], TASK_STATES["INTERRUPTED"], TASK_STATES["CANCELED"], TASK_STATES["FAILED"]), title=_("Finished tasks"), order_by=["-dt_finished", "id"]), name="task/finished"),
     url(r"^(?P<id>\d+)/log/(?P<log_name>.+)$", "kobo.hub.views.task_log", name="task/log"),
     url(r"^(?P<id>\d+)/log-json/(?P<log_name>.+)$", "kobo.hub.views.task_log_json", name="task/log-json"),
-)
+]

--- a/kobo/hub/urls/user.py
+++ b/kobo/hub/urls/user.py
@@ -2,13 +2,13 @@
 
 
 from django.contrib.auth import get_user_model
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.utils.translation import ugettext_lazy as _
 from kobo.django.views.generic import ExtraListView
 from kobo.hub.views import UserDetailView
 
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^$", ExtraListView.as_view(
         queryset=get_user_model().objects.order_by("username"),
         template_name="user/list.html",
@@ -16,4 +16,4 @@ urlpatterns = patterns("",
         title = _('Users'),
     ), name="user/list"),
     url(r"^(?P<pk>\d+)/$", UserDetailView.as_view(), name="user/detail"),
-)
+]

--- a/kobo/hub/urls/worker.py
+++ b/kobo/hub/urls/worker.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.utils.translation import ugettext_lazy as _
 from kobo.django.views.generic import ExtraListView, ExtraDetailView
 from kobo.hub.models import Worker
 
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^$", ExtraListView.as_view(
         queryset=Worker.objects.order_by("name"),
         template_name="worker/list.html",
@@ -20,4 +20,4 @@ urlpatterns = patterns("",
         context_object_name="worker",
         title=_("Worker detail"),
     ), name="worker/detail"),
-)
+]

--- a/tests/hub_urls.py
+++ b/tests/hub_urls.py
@@ -1,11 +1,13 @@
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 from django.contrib import admin
 from django.http import HttpResponse
+
 
 def home(request):
     return HttpResponse("Index", status=200, content_type="text/plain")
 
-urlpatterns = patterns("",
+
+urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r"^auth/", include("kobo.hub.urls.auth")),
     url(r"^home/$", home, name="home/index"),
@@ -14,4 +16,4 @@ urlpatterns = patterns("",
     url(r"^info/channel/", include("kobo.hub.urls.channel")),
     url(r"^info/user/", include("kobo.hub.urls.user")),
     url(r"^info/worker/", include("kobo.hub.urls.worker")),
-)
+]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.sessions',
+    'kobo.django',
     'kobo.hub',
 )
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import django
+
+# Only for Django >= 1.7
+if 'setup' in dir(django):
+    # This has to happen before below imports because they have a hard requirement
+    # on settings being loaded before import.
+    django.setup()
+
 import unittest2 as unittest
 
 from mock import Mock, PropertyMock, patch

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import django
+
+# Only for Django >= 1.7
+if 'setup' in dir(django):
+    # This has to happen before below imports because they have a hard requirement
+    # on settings being loaded before import.
+    django.setup()
+
 import unittest
 from six import BytesIO
 


### PR DESCRIPTION
- Rewrite url patters to be compatible with 1.9 and beyond
- Fix test setups for 1.9 and beyond

This won't work on 1.6 or anything before.

Test on 1.9 runs, but there are some tests that needs fixing
due some changes in the Django itself. Just 6 tests are
failing on Django 1.9.