### PR TITLE
Remove py2.6 packages from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,6 @@ basepython =
 deps =
     -rtest-requirements.txt
     django18: -cconstraints-django18.txt
-    # On python 2.6, we must install older versions of
-    # a few deps explicitly, as the implicitly selected versions
-    # won't support 2.6
-    py26: idna==2.7
-    py26: pycparser==2.18
-    py26: pyOpenSSL==17.5.0
 
 [testenv:py36-cov-travis]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
Supported for Python 2.6 was dropped
but seens that these packages were forgotten.