### PR TITLE
Decode RPM headers only if not decoded already

### DIFF
--- a/kobo/pkgset.py
+++ b/kobo/pkgset.py
@@ -176,19 +176,17 @@ class SimpleRpmWrapper(FileWrapper):
         ts = kwargs.pop("ts", None)
         header = kobo.rpmlib.get_rpm_header(file_path, ts=ts)
 
-        self.name = kobo.rpmlib.get_header_field(header, "name").decode('utf-8')
-        self.version = kobo.rpmlib.get_header_field(header, "version").decode('utf-8')
-        self.release = kobo.rpmlib.get_header_field(header, "release").decode('utf-8')
+        self.name = kobo.rpmlib.get_header_field(header, "name")
+        self.version = kobo.rpmlib.get_header_field(header, "version")
+        self.release = kobo.rpmlib.get_header_field(header, "release")
         self.epoch = kobo.rpmlib.get_header_field(header, "epoch")
-        self.arch = kobo.rpmlib.get_header_field(header, "arch").decode('utf-8')
+        self.arch = kobo.rpmlib.get_header_field(header, "arch")
         self.signature = kobo.rpmlib.get_keys_from_header(header)
         if self.signature is not None:
             self.signature = self.signature.upper()
-        self.excludearch = [x.decode('utf-8') for x in kobo.rpmlib.get_header_field(header, "excludearch")]
-        self.exclusivearch = [x.decode('utf-8') for x in kobo.rpmlib.get_header_field(header, "exclusivearch")]
+        self.excludearch = kobo.rpmlib.get_header_field(header, "excludearch")
+        self.exclusivearch = kobo.rpmlib.get_header_field(header, "exclusivearch")
         self.sourcerpm = kobo.rpmlib.get_header_field(header, "sourcerpm")
-        if self.sourcerpm:
-            self.sourcerpm = self.sourcerpm.decode('utf-8')
         self.is_source = bool(kobo.rpmlib.get_header_field(header, "sourcepackage"))
         self.is_system_release = b"system-release" in kobo.rpmlib.get_header_field(header, "providename")
         self.checksum_type = kobo.rpmlib.get_digest_algo_from_header(header).lower()

--- a/kobo/rpmlib.py
+++ b/kobo/rpmlib.py
@@ -119,6 +119,18 @@ def get_header_field(hdr, name):
             result = []
         elif isinstance(result, six.integer_types):
             result = [result]
+
+    if six.PY3:
+        # We are on Python 3 with python3-rpm <= 4.14.2 that returns bytes, the
+        # value needs to be decoded. Newer versions of python3-rpm will do the
+        # decoding by themselves and don't need to be handled here.
+        if isinstance(result, bytes):
+            result = result.decode("utf-8", "surrogateescape")
+        if isinstance(result, list):
+            result = [
+                x.decode("utf-8", "surrogateescape") if isinstance(x, bytes) else x
+                for x in result
+            ]
     return result
 
 


### PR DESCRIPTION
Recent RPM decodes the value and returns str directly. That breaks when kobo tries to decode it again. With this patch only bytes will be decoded.

Relates: https://bugzilla.redhat.com/show_bug.cgi?id=1693751
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1713107

@hroncok or @frenzymadness , can you please sanity check if this makes sense?

I'll try to set up a test environment on Rawhide with newer RPM and run some tests.