### PR TITLE
Fix returned static values form get_header_field

### DIFF
--- a/kobo/rpmlib.py
+++ b/kobo/rpmlib.py
@@ -92,15 +92,15 @@ def get_header_field(hdr, name):
     @param name: a rpm field name
     @type name: str
     @return: value of a rpm field
-    @rtype: bytes or int or list
+    @rtype: str or int or list
     """
 
     if name == "arch":
         # HACK: return "src" or "nosrc" arch instead of build arch
         if get_header_field(hdr, "sourcepackage"):
             if get_header_field(hdr, "nosource") or get_header_field(hdr, "nopatch"):
-                return b"nosrc"
-            return b"src"
+                return "nosrc"
+            return "src"
 
     hdr_key = getattr(rpm, "RPMTAG_%s" % name.upper(), None)
     if hdr_key is None:


### PR DESCRIPTION
After #115 the function should always return str and not bytes. Also the docstring is updated to match reality.