### PR TITLE
Python 3 compatible force_list and force_tuple

### DIFF
--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -19,6 +19,11 @@ import six
 from six.moves import range
 from six.moves import shlex_quote
 
+if six.PY3:
+    from collections.abc import KeysView
+else:
+    from collections import KeysView
+
 __all__ = (
     "force_list",
     "force_tuple",
@@ -50,10 +55,12 @@ def force_list(value):
 
     @rtype: list
     """
-    if type(value) is list:
+    if isinstance(value, list):
         return value
-    if type(value) in (tuple, set):
+
+    if isinstance(value, (tuple, set, KeysView)):
         return list(value)
+
     return [value]
 
 
@@ -62,10 +69,12 @@ def force_tuple(value):
 
     @rtype: tuple
     """
-    if type(value) is tuple:
+    if isinstance(value, tuple):
         return value
-    if type(value) in (list, set):
+
+    if isinstance(value, (list, set, KeysView)):
         return tuple(value)
+
     return (value, )
 
 

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -19,12 +19,14 @@ class TestShortcuts(unittest.TestCase):
         self.assertEqual(force_list("a"), ["a"])
         self.assertEqual(force_list(["a"]), ["a"])
         self.assertEqual(force_list(["a", "b"]), ["a", "b"])
+        self.assertItemsEqual(force_list({'a': True, 'b': True}.keys()), ["a", "b"])
         self.assertItemsEqual(force_list(set(["a", "b"])), ["a", "b"])
 
     def test_force_tuple(self):
         self.assertItemsEqual(force_tuple("a"), ("a",))
         self.assertItemsEqual(force_tuple(("a",)), ("a",))
         self.assertItemsEqual(force_tuple(("a", "b")), ("a", "b"))
+        self.assertItemsEqual(force_tuple({'a': True, 'b': True}.keys()), ("a", "b"))
         self.assertItemsEqual(force_tuple(set(["a", "b"])), ("a", "b"))
 
     def test_allof(self):


### PR DESCRIPTION
Allow force_list and force_tuple to convert dict_keys
to list and/or tuple.

This fixes #128.