### PR TITLE
Improve python3 and Django 1.11 and 2.x compatibility

### DIFF
--- a/kobo/admin/templates/hub/settings.py.template
+++ b/kobo/admin/templates/hub/settings.py.template
@@ -124,6 +124,7 @@ TEMPLATE_DIRS = (
 INSTALLED_APPS = (
     'kobo.django.auth',   # load this app first to make sure the username length hack is applied first
     'django.contrib.auth',
+    'django.contrib.staticfiles',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',

--- a/kobo/admin/templates/hub/templates/base.html
+++ b/kobo/admin/templates/hub/templates/base.html
@@ -1,9 +1,10 @@
 {% extends "layout.html" %}
 {% load i18n %}
+{% load staticfiles %}
 
 {% block css %}
   {# change href according to your project or remove following line completely #}
-  <link rel="stylesheet" href="{{ STATIC_URL }}css/style.css" type="text/css" media="screen" />
+  <link rel="stylesheet" href="{% static "css/style.css" %}" type="text/css" media="screen" />
 {% endblock %}
 
 {% block header_site_name %}

--- a/kobo/django/django_version.py
+++ b/kobo/django/django_version.py
@@ -1,0 +1,10 @@
+import django
+from distutils.version import LooseVersion
+
+def django_version_ge(version_str):
+    """
+    Check if current django is in highier or equal version than specified by
+    version_str parameter
+    """
+
+    return LooseVersion(django.get_version()) >= LooseVersion(version_str)

--- a/kobo/django/forms.py
+++ b/kobo/django/forms.py
@@ -58,6 +58,10 @@ class JSONWidget(django.forms.widgets.Textarea):
 class JSONFormField(django.forms.fields.CharField):
     widget = JSONWidget
 
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
+
+
     def to_python(self, value):
         try:
             result = json.loads(value)

--- a/kobo/django/menu/__init__.py
+++ b/kobo/django/menu/__init__.py
@@ -93,7 +93,11 @@ from six.moves import range
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from kobo.django.django_version import django_version_ge
+if django_version_ge('1.10.0'):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 
 try:

--- a/kobo/django/upload/admin.py
+++ b/kobo/django/upload/admin.py
@@ -3,7 +3,7 @@
 
 import django.contrib.admin as admin
 
-from models import FileUpload
+from .models import FileUpload
 
 
 class FileUploadAdmin(admin.ModelAdmin):

--- a/kobo/django/upload/models.py
+++ b/kobo/django/upload/models.py
@@ -21,7 +21,7 @@ UPLOAD_STATES = Enum(
 
 
 class FileUpload(models.Model):
-    owner       = models.ForeignKey(settings.AUTH_USER_MODEL)
+    owner       = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     name        = models.CharField(max_length=255)
     checksum    = models.CharField(max_length=255)
     size        = models.PositiveIntegerField()

--- a/kobo/django/upload/urls.py
+++ b/kobo/django/upload/urls.py
@@ -2,8 +2,9 @@
 
 
 from django.conf.urls.defaults import url
+import kobo.django.upload.views
 
 
 urlpatterns = [
-    url(r"^$", "kobo.django.upload.views.file_upload"),
+    url(r"^$", kobo.django.upload.views.file_upload),
 ]

--- a/kobo/django/upload/xmlrpc.py
+++ b/kobo/django/upload/xmlrpc.py
@@ -5,7 +5,7 @@ import os
 
 from django.conf import settings
 
-from models import FileUpload
+from .models import FileUpload
 from kobo.django.xmlrpc.decorators import login_required
 
 

--- a/kobo/django/xmlrpc/views.py
+++ b/kobo/django/xmlrpc/views.py
@@ -36,7 +36,7 @@ import django.db
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
-from django.template import Template, loader
+from django.template import Template, loader, Context
 
 from kobo.django.xmlrpc.dispatcher import DjangoXMLRPCDispatcher
 
@@ -152,10 +152,10 @@ class XMLRPCHandlerFactory(object):
                     "help": self.xmlrpc_dispatcher.system_methodHelp(method).split("\n"),
                 })
 
-            c = {
+            c = Context({
                 "title": "XML-RPC interface (%s)" % self.name,
                 "method_list": method_list,
-            }
+            })
 
             template = getattr(settings, "XMLRPC_TEMPLATE", None)
             if template is not None:
@@ -163,7 +163,7 @@ class XMLRPCHandlerFactory(object):
             else:
                 t = Template(XMLRPC_TEMPLATE, name="XML-RPC template")
 
-            return HttpResponse(t.render(c, request))
+            return HttpResponse(t.render(c))
 
 
 for var in ("XMLRPC_METHODS", ):

--- a/kobo/hub/migrations/0001_initial.py
+++ b/kobo/hub/migrations/0001_initial.py
@@ -51,8 +51,8 @@ class Migration(migrations.Migration):
                 ('priority', models.PositiveIntegerField(default=10, help_text='Priority.')),
                 ('weight', models.PositiveIntegerField(default=1, help_text='Weight determines how many resources is used when processing the task.')),
                 ('subtask_count', models.PositiveIntegerField(default=0, help_text='Subtask count.<br />This is a generated field.')),
-                ('arch', models.ForeignKey(to='hub.Arch')),
-                ('channel', models.ForeignKey(to='hub.Channel')),
+                ('arch', models.ForeignKey(to='hub.Arch', on_delete=models.CASCADE)),
+                ('channel', models.ForeignKey(to='hub.Channel', on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('-id',),

--- a/kobo/hub/migrations/0002_auto_20150722_0612.py
+++ b/kobo/hub/migrations/0002_auto_20150722_0612.py
@@ -16,26 +16,31 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='task',
             name='owner',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='task',
             name='parent',
-            field=models.ForeignKey(blank=True, to='hub.Task', help_text='Parent task.', null=True),
+            field=models.ForeignKey(blank=True, to='hub.Task', help_text='Parent task.',
+                on_delete=models.CASCADE, null=True),
         ),
         migrations.AddField(
             model_name='task',
             name='resubmitted_by',
-            field=models.ForeignKey(related_name='resubmitted_by1', blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(related_name='resubmitted_by1', blank=True,
+                to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True),
         ),
         migrations.AddField(
             model_name='task',
             name='resubmitted_from',
-            field=models.ForeignKey(related_name='resubmitted_from1', blank=True, to='hub.Task', null=True),
+            field=models.ForeignKey(related_name='resubmitted_from1',
+                blank=True, to='hub.Task', on_delete=models.CASCADE, null=True),
         ),
         migrations.AddField(
             model_name='task',
             name='worker',
-            field=models.ForeignKey(blank=True, to='hub.Worker', help_text='A worker which has this task assigned.', null=True),
+            field=models.ForeignKey(blank=True, to='hub.Worker',
+                help_text='A worker which has this task assigned.',
+                on_delete=models.CASCADE, null=True),
         ),
     ]

--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -487,9 +487,9 @@ class TaskLogs(object):
 class Task(models.Model):
     """Model for hub_task table."""
     archive             = models.BooleanField(default=False, help_text=_("When a task is archived, it disappears from admin interface and cannot be accessed by taskd.<br />Make sure that archived tasks are finished and you won't need them anymore."))
-    owner               = models.ForeignKey(settings.AUTH_USER_MODEL)
-    worker              = models.ForeignKey(Worker, null=True, blank=True, help_text=_("A worker which has this task assigned."))
-    parent              = models.ForeignKey("self", null=True, blank=True, help_text=_("Parent task."))
+    owner               = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    worker              = models.ForeignKey(Worker, null=True, blank=True, help_text=_("A worker which has this task assigned."), on_delete=models.CASCADE)
+    parent              = models.ForeignKey("self", null=True, blank=True, help_text=_("Parent task."), on_delete=models.CASCADE)
     state               = models.PositiveIntegerField(default=TASK_STATES["FREE"], choices=TASK_STATES.get_mapping(), help_text=_("Current task state."))
     label               = models.CharField(max_length=255, blank=True, help_text=_("Label, description or any reason for this task."))
     exclusive           = models.BooleanField(default=False, help_text=_("Exclusive tasks have highest priority. They are used e.g. when shutting down a worker."))
@@ -499,8 +499,8 @@ class Task(models.Model):
     result              = models.TextField(blank=True, help_text=_("Task result. Do not store a lot of data here (use HubProxy.upload_task_log instead)."))
     comment             = models.TextField(null=True, blank=True)
 
-    arch                = models.ForeignKey(Arch)
-    channel             = models.ForeignKey(Channel)
+    arch                = models.ForeignKey(Arch, on_delete=models.CASCADE)
+    channel             = models.ForeignKey(Channel, on_delete=models.CASCADE)
     timeout             = models.PositiveIntegerField(null=True, blank=True, help_text=_("Task timeout. Leave blank for no timeout."))
 
     waiting             = models.BooleanField(default=False, help_text=_("Task is waiting until some subtasks finish."))
@@ -513,8 +513,8 @@ class Task(models.Model):
     priority            = models.PositiveIntegerField(default=10, help_text=_("Priority."))
     weight              = models.PositiveIntegerField(default=1, help_text=_("Weight determines how many resources is used when processing the task."))
 
-    resubmitted_by      = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, related_name="resubmitted_by1")
-    resubmitted_from    = models.ForeignKey("self", null=True, blank=True, related_name="resubmitted_from1")
+    resubmitted_by      = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, related_name="resubmitted_by1", on_delete=models.CASCADE)
+    resubmitted_from    = models.ForeignKey("self", null=True, blank=True, related_name="resubmitted_from1", on_delete=models.CASCADE)
 
     subtask_count       = models.PositiveIntegerField(default=0, help_text=_("Subtask count.<br />This is a generated field."))
 

--- a/kobo/hub/templates/base.html.example
+++ b/kobo/hub/templates/base.html.example
@@ -1,8 +1,9 @@
 {% extends "layout.html" %}
 {% load i18n %}
+{% load staticfiles %}
 
 {% block css %}
-  <link rel="stylesheet" href="{{ STATIC_URL }}css/style.css" type="text/css" media="screen" />
+  <link rel="stylesheet" href="{% static "css/style.css" %}" type="text/css" media="screen" />
 {% endblock %}
 
 {% block header_site_name %}

--- a/kobo/hub/templates/layout.html
+++ b/kobo/hub/templates/layout.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-loose.dtd">
+{% load staticfiles %}
+
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 <head>
   <title>{{ title }}</title>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <link rel="stylesheet" href="{{ STATIC_URL }}kobo/css/screen.css" type="text/css" media="screen" />
+  <link rel="stylesheet" href="{% static "kobo/css/screen.css" %}" type="text/css" media="screen" />
 {% block css %}
 {% endblock %}
 {% block head %}

--- a/kobo/hub/templates/pagination.html
+++ b/kobo/hub/templates/pagination.html
@@ -1,21 +1,22 @@
 {% load i18n %}
+{% load staticfiles %}
 
 {% if page_obj.has_other_pages %}
 <div class="paginator">
   {% trans "Page" %} {{ page_obj.number }}/{{ paginator.num_pages }}. {% trans "Records" %} {{ page_obj.start_index }} - {{ page_obj.end_index }} {% trans "of" %} {{ paginator.count }}.
 {% if page_obj.has_previous %}
-  <a href="?page=1{{ get_vars }}"><img src="{{ STATIC_URL }}kobo/img/list-first.png" /></a>
-  <a href="?page={{ page_obj.previous_page_number }}{{ get_vars }}"><img src="{{ STATIC_URL }}kobo/img/list-prev.png" /></a>
+  <a href="?page=1{{ get_vars }}"><img src="{% static "kobo/img/list-first.png" %}" /></a>
+  <a href="?page={{ page_obj.previous_page_number }}{{ get_vars }}"><img src="{% static "kobo/img/list-prev.png" %}"/></a>
 {% else %}
-  <img src="{{ STATIC_URL }}kobo/img/list-first-disabled.png" />
-  <img src="{{ STATIC_URL }}kobo/img/list-prev-disabled.png" />
+  <img src="{% static "kobo/img/list-first-disabled.png" %}"  />
+  <img src="{% static "kobo/img/list-prev-disabled.png" %}" />
 {% endif %}
 {% if page_obj.has_next %}
-  <a href="?page={{ page_obj.next_page_number }}{{ get_vars }}"><img src="{{ STATIC_URL }}kobo/img/list-next.png" /></a>
-  <a href="?page={{ paginator.num_pages }}{{ get_vars }}"><img src="{{ STATIC_URL }}kobo/img/list-last.png" /></a>
+  <a href="?page={{ page_obj.next_page_number }}{{ get_vars }}"><img src="{% static "kobo/img/list-next.png" %}" /></a>
+  <a href="?page={{ paginator.num_pages }}{{ get_vars }}"><img src="{% static "kobo/img/list-last.png" %}"/></a>
 {% else %}
-  <img src="{{ STATIC_URL }}kobo/img/list-next-disabled.png" />
-  <img src="{{ STATIC_URL }}kobo/img/list-last-disabled.png" />
+  <img src="{% static "kobo/img/list-next-disabled.png" %}" />
+  <img src="{% static "kobo/img/list-last-disabled.png" %}" />
 {% endif %}
 </div>
 <div style="clear: both" />

--- a/kobo/hub/templates/task/log.html
+++ b/kobo/hub/templates/task/log.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load staticfiles %}
 
 {% block head %}
-<script type="text/javascript" src="{{ STATIC_URL }}kobo/js/log_watcher.js"></script>
+<script type="text/javascript" src="{% static "kobo/js/log_watcher.js" %}"></script>
 <script type="text/javascript" language="javascript">
 document.log_watcher = new LogWatcher('{{ json_url }}', {{ offset }}, {{ task_finished }}, {{ next_poll }});
 document.log_watcher.watch();

--- a/kobo/hub/urls/auth.py
+++ b/kobo/hub/urls/auth.py
@@ -3,10 +3,18 @@
 
 from django.conf.urls import url
 import kobo.hub.views
+from kobo.django.django_version import django_version_ge
 
+if django_version_ge('1.11.0'):
+    urlpatterns = [
+        url(r"^login/$", kobo.hub.views.LoginView.as_view(), name="auth/login"),
+        url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
+        url(r'^logout/$', kobo.hub.views.logout, name="auth/logout"),
+    ]
 
-urlpatterns = [
-    url(r"^login/$", kobo.hub.views.login, name="auth/login"),
-    url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
-    url(r'^logout/$', kobo.hub.views.logout, name="auth/logout"),
-]
+else:
+    urlpatterns = [
+        url(r"^login/$", kobo.hub.views.login, name="auth/login"),
+        url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
+        url(r'^logout/$', kobo.hub.views.logout, name="auth/logout"),
+    ]

--- a/kobo/hub/urls/auth.py
+++ b/kobo/hub/urls/auth.py
@@ -9,7 +9,7 @@ if django_version_ge('1.11.0'):
     urlpatterns = [
         url(r"^login/$", kobo.hub.views.LoginView.as_view(), name="auth/login"),
         url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
-        url(r'^logout/$', kobo.hub.views.logout, name="auth/logout"),
+        url(r'^logout/$', kobo.hub.views.LogoutView.as_view(), name="auth/logout"),
     ]
 
 else:

--- a/kobo/hub/urls/auth.py
+++ b/kobo/hub/urls/auth.py
@@ -2,10 +2,11 @@
 
 
 from django.conf.urls import url
+import kobo.hub.views
 
 
 urlpatterns = [
-    url(r"^login/$", "kobo.hub.views.login", name="auth/login"),
-    url(r"^krb5login/$", "kobo.hub.views.krb5login", name="auth/krb5login"),
-    url(r'^logout/$', 'kobo.hub.views.logout', name="auth/logout"),
+    url(r"^login/$", kobo.hub.views.login, name="auth/login"),
+    url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
+    url(r'^logout/$', kobo.hub.views.logout, name="auth/logout"),
 ]

--- a/kobo/hub/urls/task.py
+++ b/kobo/hub/urls/task.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.conf.urls import url
 from kobo.hub.models import TASK_STATES
 from kobo.hub.views import TaskListView, TaskDetail
+import kobo.hub.views
 
 
 urlpatterns = [
@@ -12,6 +13,6 @@ urlpatterns = [
     url(r"^(?P<pk>\d+)/$", TaskDetail.as_view(), name="task/detail"),
     url(r"^running/$", TaskListView.as_view(state=(TASK_STATES["FREE"], TASK_STATES["ASSIGNED"], TASK_STATES["OPEN"]), title=_("Running tasks"), order_by=["id"]), name="task/running"),
     url(r"^finished/$", TaskListView.as_view(state=(TASK_STATES["CLOSED"], TASK_STATES["INTERRUPTED"], TASK_STATES["CANCELED"], TASK_STATES["FAILED"]), title=_("Finished tasks"), order_by=["-dt_finished", "id"]), name="task/finished"),
-    url(r"^(?P<id>\d+)/log/(?P<log_name>.+)$", "kobo.hub.views.task_log", name="task/log"),
-    url(r"^(?P<id>\d+)/log-json/(?P<log_name>.+)$", "kobo.hub.views.task_log_json", name="task/log-json"),
+    url(r"^(?P<id>\d+)/log/(?P<log_name>.+)$", kobo.hub.views.task_log, name="task/log"),
+    url(r"^(?P<id>\d+)/log-json/(?P<log_name>.+)$", kobo.hub.views.task_log_json, name="task/log-json"),
 ]

--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -14,7 +14,11 @@ import django.contrib.auth.views
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, get_user_model
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from kobo.django.django_version import django_version_ge
+if django_version_ge('1.10.0'):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.http import HttpResponse, StreamingHttpResponse, HttpResponseForbidden
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext

--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -4,6 +4,7 @@ import mimetypes
 import os
 import six
 import locale
+from kobo.django.django_version import django_version_ge
 
 try:
     import json
@@ -241,9 +242,13 @@ def task_log_json(request, id, log_name):
 
     return HttpResponse(json.dumps(result), content_type="application/json")
 
+if django_version_ge('1.11.0'):
+    class LoginView(django.contrib.auth.views.LoginView):
+        template_name = 'auth/login.html'
 
-def login(request, redirect_field_name=REDIRECT_FIELD_NAME):
-    return django.contrib.auth.views.login(request, template_name="auth/login.html", redirect_field_name=redirect_field_name)
+else:
+    def login(request, redirect_field_name=REDIRECT_FIELD_NAME):
+        return django.contrib.auth.views.login(request, template_name="auth/login.html", redirect_field_name=redirect_field_name)
 
 
 def krb5login(request, redirect_field_name=REDIRECT_FIELD_NAME):

--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -246,9 +246,15 @@ if django_version_ge('1.11.0'):
     class LoginView(django.contrib.auth.views.LoginView):
         template_name = 'auth/login.html'
 
+    class LogoutView(django.contrib.auth.views.LogoutView):
+        pass
+
 else:
     def login(request, redirect_field_name=REDIRECT_FIELD_NAME):
         return django.contrib.auth.views.login(request, template_name="auth/login.html", redirect_field_name=redirect_field_name)
+
+    def logout(request, redirect_field_name=REDIRECT_FIELD_NAME):
+        return django.contrib.auth.views.logout(request, redirect_field_name=redirect_field_name)
 
 
 def krb5login(request, redirect_field_name=REDIRECT_FIELD_NAME):
@@ -260,7 +266,4 @@ def krb5login(request, redirect_field_name=REDIRECT_FIELD_NAME):
     if not redirect_to:
         redirect_to = reverse("home/index")
     return RedirectView.as_view(url=redirect_to)(request)
-    
 
-def logout(request, redirect_field_name=REDIRECT_FIELD_NAME):
-    return django.contrib.auth.views.logout(request, redirect_field_name=redirect_field_name)

--- a/kobo/hub/xmlrpc/client.py
+++ b/kobo/hub/xmlrpc/client.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
 
-from django.core.urlresolvers import reverse
+from kobo.django.django_version import django_version_ge
+if django_version_ge('1.10.0'):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
 
 from kobo.hub import models


### PR DESCRIPTION
Currently kobo is not able to work with Django 2.x flawlessly. Improve Django 1.11 and 2.x compatibility, preserving  backwards compatibility with Django 1.7.