### PR TITLE
Fix shortcuts.run crashes in text mode in python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ matrix:
     env: TOXENV=py35-django18
   - python: "3.6"
     env: TOXENV=py36-django18 DEPLOY=1
-  - python: "3.6"
-    env: TOXENV=py36-cov-travis
+  - python: "3.7"
+    env: TOXENV=py37-django18
+  - python: "3.7"
+    env: TOXENV=py37-cov-travis
 
 deploy:
   # Tagging a new kobo automatically releases to PyPI.

--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -291,7 +291,7 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
 
     # any of these args is passed, text mode will be enabled.
     is_text_mode = any([universal_newlines, text, encoding, errors])
-    encoding_method = encoding or 'utf-8'
+    encoding = encoding or 'utf-8'
 
     log = None
     if logfile:
@@ -316,7 +316,7 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
             if logfile:
                 if six.PY3 and not is_text_mode:
                     # Log file opened as binary, encode the command
-                    command = bytes(command, encoding=encoding_method)
+                    command = bytes(command, encoding=encoding)
                 log.write(command)
 
         stdin = None
@@ -355,7 +355,7 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
                 break
             if stdout:
                 if not is_text_mode:
-                    sys.stdout.write(lines.decode(encoding_method))
+                    sys.stdout.write(lines.decode(encoding))
                 else:
                     sys.stdout.write(lines)
             if logfile:

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -4,8 +4,10 @@
 
 import mock
 import unittest2 as unittest
+import pytest
 
 import os
+import sys
 import shutil
 import tempfile
 from six.moves import StringIO
@@ -175,6 +177,24 @@ class TestUtils(unittest.TestCase):
         self.assertRaises(RuntimeError, run, "echo foo | tee >(md5sum -b) >/dev/null")
         # passes in bash
         run("echo foo | tee >(md5sum -b) >/dev/null", executable="/bin/bash")
+
+    @pytest.mark.xfail(sys.version_info < (3, 7), reason="python3.7 api changes")
+    def test_run_in_text_mode(self):
+        """test run with kwargs 'text', 'encoding' or/and 'errors' set. These kwargs are
+        added to Popen from python3.6(encoding, errors) and python3.7(text). Running test
+        with python version older than 3.7 is expected to fail
+        """
+        ret, out = run("echo hello", text=True)
+        self.assertEqual(ret, 0)
+        self.assertEqual(out, "hello\n")
+
+        ret, out = run("echo hello", encoding="utf-8")
+        self.assertEqual(ret, 0)
+        self.assertEqual(out, "hello\n")
+
+        ret, out = run("echo hello", errors="strict")
+        self.assertEqual(ret, 0)
+        self.assertEqual(out, "hello\n")
 
     @mock.patch('sys.stdout', new_callable=StringIO)
     def test_run_univ_nl_show_cmd_logfile_stdout(self, mock_out):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-django18
+envlist = {py27,py34,py35,py36,py37}-django18
 skip_missing_interpreters = True
 
 [testenv]
@@ -10,11 +10,12 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 deps =
     -rtest-requirements.txt
     django18: -cconstraints-django18.txt
 
-[testenv:py36-cov-travis]
+[testenv:py37-cov-travis]
 passenv = TRAVIS TRAVIS_*
 deps=
     -rtest-requirements.txt


### PR DESCRIPTION
In python3, some new args are introduced to Popen, which are 'text',
'encoding' and 'errors', when any of these args is set, Popen will
enable the text mode, leading shortcuts.run to crash.
This patch makes it recognize and be able to deal with these new args.