### PR TITLE
Fix backwards-incompatible MIDDLEWARE check

### DIFF
--- a/kobo/hub/__init__.py
+++ b/kobo/hub/__init__.py
@@ -24,9 +24,11 @@ for var in ["TASK_DIR", "UPLOAD_DIR"]:
         raise ImproperlyConfigured("Invalid permissions on '%s'." % dir_path)
 
 
-if django_version_ge("1.10.0"):
+if getattr(settings, "MIDDLEWARE", None) is not None:
+    # Settings defines Django>=1.10 style middleware, check that
     middleware_var = "MIDDLEWARE"
 else:
+    # Legacy
     middleware_var = "MIDDLEWARE_CLASSES"
 
 for var, value in [(middleware_var, "kobo.hub.middleware.WorkerMiddleware")]:


### PR DESCRIPTION
The logic here was: if Django 1.10 or greater is used, then
check the MIDDLEWARE variable.  Else check MIDDLEWARE_CLASSES.

This isn't correct, as Django 1.10 added support for MIDDLEWARE
but did not remove support for MIDDLEWARE_CLASSES.  This was a
backwards-incompatible change, as an application using
MIDDLEWARE_CLASSES could work fine on kobo 0.14.0 but would start
crashing on kobo 0.15.0, for no good reason.

Fix it so it's backwards-compatible. There are Django versions
supporting both MIDDLEWARE or MIDDLEWARE_CLASSES, so the only way
we can know which one to check is to probe which one has been
defined.