### PR TITLE
Fix middleware TypeError where ImproperlyConfigured was expected

### DIFF
--- a/kobo/hub/__init__.py
+++ b/kobo/hub/__init__.py
@@ -30,5 +30,5 @@ else:
     middleware_var = "MIDDLEWARE_CLASSES"
 
 for var, value in [(middleware_var, "kobo.hub.middleware.WorkerMiddleware")]:
-    if not hasattr(settings, var) or value not in getattr(settings, var, []):
+    if value not in (getattr(settings, var, None) or []):
         raise ImproperlyConfigured("'%s' in '%s' is missing in project settings. It must be set to run kobo.hub app." % (value, var))


### PR DESCRIPTION
"getattr(settings, var, [])" is not a valid way of defaulting
any empty value into an empty list. If the value is present but
None, it will evaluate to None, which then crashes due to
attempting to evaluate "value not in None". Rewrite it to tolerate
values which are present but None.

Additionally, using hasattr together with a call to getattr
providing a default value is pointless, so it was dropped.
The default value in getattr only applies if the object doesn't
have the attribute, in which case we can't possibly have passed
the hasattr check, so the former default of [] was never used.

In practice, this would happen with MIDDLEWARE on some versions
of Django, which globally defaults to None. This was a low impact
bug, since it only converted one type of crash into another.