### PR TITLE
HubProxy: remove broken auto_logout feature

### DIFF
--- a/tests/test_hubproxy.py
+++ b/tests/test_hubproxy.py
@@ -156,3 +156,13 @@ def test_login_gssapi_principal_needs_keytab(requests_session):
     logger.debug.assert_called_with(
         "Failed to create new session: Cannot specify a principal without a keytab"
     )
+
+
+def test_no_auto_logout(requests_session):
+    """auto_logout argument warns of deprecation"""
+    conf = PyConfigParser()
+    conf.load_from_dict({"HUB_URL": 'https://example.com/hub'})
+
+    transport = FakeTransport()
+    with pytest.deprecated_call():
+        HubProxy(conf, transport=transport, auto_logout=True)

--- a/tests/test_hubproxy.py
+++ b/tests/test_hubproxy.py
@@ -1,6 +1,7 @@
 import pytest
 import gssapi
 import mock
+import sys
 
 from kobo.xmlrpc import SafeCookieTransport
 from kobo.conf import PyConfigParser
@@ -25,8 +26,17 @@ class FakeTransport(SafeCookieTransport):
 
     Subclasses the real SafeCookieTransport so we get a real CookieJar.
     """
+    def __init__(self, *args, **kwargs):
+        # note: py2 transport classes do not subclass object
+        if sys.version_info[0] < 3:
+            SafeCookieTransport.__init__(self, *args, **kwargs)
+        else:
+            super().__init__(*args, **kwargs)
+
+        self.fake_transport_calls = []
 
     def request(self, host, path, request, verbose=False):
+        self.fake_transport_calls.append((path, request))
         return []
 
 
@@ -166,3 +176,18 @@ def test_no_auto_logout(requests_session):
     transport = FakeTransport()
     with pytest.deprecated_call():
         HubProxy(conf, transport=transport, auto_logout=True)
+
+
+def test_proxies_to_xmlrpc(requests_session):
+    """HubProxy proxies to underlying XML-RPC ServerProxy"""
+    conf = PyConfigParser()
+    conf.load_from_dict({"HUB_URL": 'https://example.com/hub'})
+
+    transport = FakeTransport()
+    proxy = HubProxy(conf, transport=transport)
+
+    proxy.some_obj.some_method()
+
+    # Last call should have invoked the method I requested
+    (_, request_xml) = transport.fake_transport_calls[-1]
+    assert b'some_obj.some_method' in request_xml


### PR DESCRIPTION
This class had an implementation of \_\_del\_\_ to automate a call
to logout when instances are finalized.  This is not a good idea
for a few reasons:

- there's no guarantee that \_\_del\_\_ is ever called, so if the logout
  here was important, this wouldn't be an appropriate way to ensure
  it happens

- \_\_del\_\_ is called at unpredictable times, as GC can be triggered
  anywhere, so doing non-trivial things such as HTTP requests is
  prone to bugs. Example: if GC starts while locks are held, the
  call to logout() itself may attempt to grab a lock which is
  already held, thus causing deadlock. This is known to happen
  with django Signal.lock when autotests are using the Django
  test client.

- it appears unimportant. The impact of logout() is to remove a
  session from the server, but the server obviously has to deal with
  expiring sessions with no explicit logout anyway.

If this feature is needed, it could be implemented by making HubProxy
a context manager which logs out during \_\_exit\_\_, but it is thought
to be not useful.