### PR TITLE
Drop admin requirement for get_worker_info

### DIFF
--- a/kobo/hub/xmlrpc/client.py
+++ b/kobo/hub/xmlrpc/client.py
@@ -51,7 +51,6 @@ def disable_worker(request, worker_name):
     """
     models.Worker.objects.filter(name=worker_name).update(enabled=False)
 
-@admin_required
 def get_worker_info(request, worker_name):
     try:
         return models.Worker.objects.get(name=worker_name).export()

--- a/tests/test_xmlrpc_client.py
+++ b/tests/test_xmlrpc_client.py
@@ -126,6 +126,20 @@ class TestXmlRpcClient(django.test.TransactionTestCase):
         info = client.get_worker_info(_make_request(), 'non-existent')
         self.assertEqual(info, {})
 
+    def test_get_worker_info_no_auth(self):
+        # Should be permissible if anonymous - no exception raised
+        client.get_worker_info(_make_request(
+            is_authenticated=False,
+            is_superuser=False,
+        ), 'worker')
+
+    def test_get_worker_info_if_authenticated_but_not_admin(self):
+        # Should be permissible if authenticated, but not admin - no exception raised
+        client.get_worker_info(_make_request(
+            is_authenticated=False,
+            is_superuser=False,
+        ), 'worker')
+
     def test_task_info(self):
         task_id = Task.create_task(self._user.username, 'label', 'method')
         task_info = client.task_info(_make_request(), task_id)
@@ -321,13 +335,6 @@ class TestXmlRpcClientAuthentication(django.test.TransactionTestCase):
                 is_superuser=False,
             ), 'worker')
 
-    def test_get_worker_info_raise_if_no_auth(self):
-        with self.assertRaises(PermissionDenied):
-            client.get_worker_info(_make_request(
-                is_authenticated=False,
-                is_superuser=False,
-            ), 'worker')
-
     def test_cancel_task_raise_if_no_auth(self):
         with self.assertRaises(PermissionDenied):
             client.cancel_task(_make_request(
@@ -366,13 +373,6 @@ class TestXmlRpcClientAuthentication(django.test.TransactionTestCase):
     def test_disable_worker_raise_if_authenticated_but_not_admin(self):
         with self.assertRaises(PermissionDenied):
             client.disable_worker(_make_request(
-                is_authenticated=False,
-                is_superuser=False,
-            ), 'worker')
-
-    def test_get_worker_info_raise_if_authenticated_but_not_admin(self):
-        with self.assertRaises(PermissionDenied):
-            client.get_worker_info(_make_request(
                 is_authenticated=False,
                 is_superuser=False,
             ), 'worker')


### PR DESCRIPTION
Worker information is useful for monitoring, in particular for looking at load and capacity information.  Better to not grant full admin rights to monitoring processes that might scrape `get_worker_info`.

This change should be reviewed with security in mind.  Is anything exposed by `get_worker_info` that shouldn't be exposed to non-admins?