### PR TITLE
Add profile support

### DIFF
--- a/kobo/client/__init__.py
+++ b/kobo/client/__init__.py
@@ -84,6 +84,7 @@ from kobo.exceptions import AuthenticationError, ImproperlyConfigured
 
 
 __all__ = (
+    "BaseClientCommandContainer",
     "CommandContainer",
     "CommandOptionParser",
     "ClientCommand",
@@ -93,12 +94,10 @@ __all__ = (
 )
 
 
-class ClientCommandContainer(kobo.cli.CommandContainer):
-
-    def __init__(self, conf, **kwargs):
+class BaseClientCommandContainer(kobo.cli.CommandContainer):
+    """A basic CommandContainer class that implements methods needed for CommandOptionParser"""
+    def __init__(self):
         self.conf = kobo.conf.PyConfigParser()
-        self.conf.load_from_conf(conf)
-        self.conf.load_from_dict(kwargs)
 
     def set_hub(self, username=None, password=None):
         if username:
@@ -109,6 +108,14 @@ class ClientCommandContainer(kobo.cli.CommandContainer):
             self.conf["PASSWORD"] = password
 
         self.hub = HubProxy(conf=self.conf)
+
+
+class ClientCommandContainer(BaseClientCommandContainer):
+    """A general-purpose subclass of BaseClientCommandContainer that loads configurations immediately at instantiation"""
+    def __init__(self, conf, **kwargs):
+        super(ClientCommandContainer, self).__init__()
+        self.conf.load_from_conf(conf)
+        self.conf.load_from_dict(kwargs)
 
 
 class ClientCommand(kobo.cli.Command):

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import unittest2 as unittest
+import os
+import tempfile
+import shutil
+
+from kobo.client import BaseClientCommandContainer, ClientCommandContainer
+from kobo.cli import CommandOptionParser
+from kobo.conf import PyConfigParser
+
+TEST_CONFIG = '''
+HUB_URL = "https://localhost/hub/xmlrpc"
+
+AUTH_METHOD = "krbv"
+'''
+
+
+class TestBaseClientCommandContainer(unittest.TestCase):
+    def setUp(self):
+        self.command_container = BaseClientCommandContainer()
+
+    def test_profile_option_unset(self):
+        parser = CommandOptionParser(command_container=self.command_container)
+        option = parser.get_option("--profile")
+
+        self.assertEqual(parser.default_profile, "")
+        self.assertEqual(option, None)
+
+    def test_profile_option_set(self):
+        parser = CommandOptionParser(command_container=self.command_container, default_profile="default-profile")
+        option = parser.get_option("--profile")
+
+        self.assertEqual(parser.default_profile, "default-profile")
+        self.assertEqual(option.get_opt_string(), "--profile")
+        self.assertEqual(option.help, "specify profile (default: default-profile)")
+
+    def test_configuration_directory_option_unset(self):
+        parser = CommandOptionParser(command_container=self.command_container, default_profile="default-profile")
+        # CommandOptionParser() doesn't store the configuration_file path in an instance variable, instead it's
+        # build in _load_profile() with the line below:
+        configuration_file = os.path.join(parser.configuration_directory, '{0}.conf'.format(parser.default_profile))
+
+        self.assertEqual(parser.configuration_directory, "/etc")
+        self.assertEqual(configuration_file, "/etc/default-profile.conf")
+
+    def test_configuration_directory_option_set(self):
+        parser = CommandOptionParser(command_container=self.command_container, default_profile="default-profile",
+                                     configuration_directory="/etc/client")
+
+        configuration_file = os.path.join(parser.configuration_directory, '{0}.conf'.format(parser.default_profile))
+
+        self.assertEqual(parser.configuration_directory, "/etc/client")
+        self.assertEqual(configuration_file, "/etc/client/default-profile.conf")
+
+
+class TestClientCommandContainer(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.conf = PyConfigParser()
+
+        self.file = os.path.join(self.dir, 'test.conf')
+
+        with open(self.file, 'w') as f:
+            f.write(TEST_CONFIG)
+
+        self.conf.load_from_file(self.file)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir)
+
+    def test_config_from_file(self):
+        container = ClientCommandContainer(self.conf)
+
+        values = {
+            'HUB_URL': 'https://localhost/hub/xmlrpc',
+            'AUTH_METHOD': 'krbv'
+        }
+        self.assertEqual(container.conf, values)
+
+    def test_config_from_kwargs(self):
+        container = ClientCommandContainer(self.conf, USERNAME='testuser')
+
+        values = {
+            'HUB_URL': 'https://localhost/hub/xmlrpc',
+            'AUTH_METHOD': 'krbv',
+            'USERNAME': 'testuser'
+        }
+        self.assertEqual(container.conf, values)


### PR DESCRIPTION
This is MR intends to address #147 through several enhancements:

* `CommandOptionParser` has two new optional parameters -- `default_profile` and `configuration_directory`
* `BaseClientCommandContainer` has been added which doesn't immediately parse configuration files, instead creating an empty container which can then be loaded once a profile has been chosen.