### PR TITLE
Check whether default_profile has been set

### DIFF
--- a/kobo/cli.py
+++ b/kobo/cli.py
@@ -286,7 +286,7 @@ class CommandOptionParser(optparse.OptionParser):
         cmd_kwargs = cmd_opts.__dict__
 
         # this block should only be evaluated if default_profile has been set at instantiation
-        if 'profile' in cmd_kwargs:
+        if self.default_profile and 'profile' in cmd_kwargs:
           self._load_profile(cmd_kwargs['profile'])
 
         cmd.run(*cmd_args, **cmd_kwargs)


### PR DESCRIPTION
Add a probably forgotten check of `default_profile` emptiness. As stated [here](https://github.com/release-engineering/kobo/pull/148/files#diff-b5927238066218040d1749f49b7613c0762910ac6cf9d6ba39d7edec8a0d6d3cR288), `_load_profile()` should be executed only if `default_profile` is set/nonempty, otherwise there is a danger of passing empty strings and getting paths like `/etc/.conf` (see issue #151).