### PR TITLE
get_query_set is deprecated

### DIFF
--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -309,9 +309,9 @@ class Worker(models.Model):
 class TaskManager(models.Manager):
     """Custom query manager for Task model."""
 
-    def get_query_set(self):
+    def get_queryset(self):
         """Redefine default query set to exclude archived tasks."""
-        return models.Manager.get_query_set(self).filter(archive=False)
+        return models.Manager.get_queryset(self).filter(archive=False)
 
     def get_and_verify(self, task_id, worker):
         return self.get(id=task_id, worker=worker)


### PR DESCRIPTION
Since Django >= 1.6, `get_query_set` is being deprecated and replaced by `get_queryset`, see
https://docs.djangoproject.com/en/dev/releases/1.6/#get-query-set-and-similar-methods-renamed-to-get-queryset