### PR TITLE
Introduce Worker.last_seen, worker's last communication with hub

### DIFF
--- a/kobo/admin/templates/hub/settings.py.template
+++ b/kobo/admin/templates/hub/settings.py.template
@@ -61,6 +61,9 @@ TASK_DIR = os.path.join(FILES_PATH, 'tasks')
 # Root directory for uploaded files
 UPLOAD_DIR = os.path.join(FILES_PATH, 'upload')
 
+# Used for additional per-worker state
+WORKER_DIR = os.path.join(FILES_PATH, 'worker')
+
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"
 MEDIA_ROOT = os.path.join(PROJECT_DIR, "media/")

--- a/kobo/hub/__init__.py
+++ b/kobo/hub/__init__.py
@@ -13,7 +13,14 @@ for var in ["XMLRPC_METHODS", "TASK_DIR", "UPLOAD_DIR"]:
         raise ImproperlyConfigured("'%s' is missing in project settings. It must be set to run kobo.hub app." % var)
 
 
-for var in ["TASK_DIR", "UPLOAD_DIR"]:
+if not hasattr(settings, "WORKER_DIR"):
+    # This setting introduced in 2021 can be defaulted to ensure backwards compatibility
+    # with existing config files.
+    worker_dir = os.path.join(os.path.dirname(settings.TASK_DIR), 'worker')
+    setattr(settings, "WORKER_DIR", worker_dir)
+
+
+for var in ["TASK_DIR", "UPLOAD_DIR", "WORKER_DIR"]:
     dir_path = getattr(settings, var)
     if not os.path.isdir(dir_path):
         try:

--- a/kobo/hub/decorators.py
+++ b/kobo/hub/decorators.py
@@ -17,6 +17,8 @@ def validate_worker(func):
         if getattr(request, 'worker', None) is None:
             raise SuspiciousOperation("User doesn't match any worker: %s" % request.user.username)
 
+        request.worker.update_last_seen()
+
         return func(request, *args, **kwargs)
 
     _new_func.__name__ = func.__name__


### PR DESCRIPTION
This commit introduces a new attribute, last_seen, onto the Worker
model used by hub. This field contains the timestamp for the worker's
last XML-RPC call to hub and is kept up-to-date automatically.
It is accessible from 'export', which means it appears in the responses
to get_worker_info method.

The motivation is to improve our ability to monitor workers.
Prior to this, no attributes on the model can be used to reliably
determine whether a worker is alive, or even whether it truly exists.
For example, a worker can have enabled=True, ready=True even if it
uses a nonexistent hostname.

The time at which a worker last called the hub is a useful signal to
determine whether workers are alive, so let's start tracking it.

Note that the way this is implemented is quite different from how it
would be in other circumstances. In particular, if this were implemented
when the model was originally defined, it'd just be another column
in the DB. The problem with doing this now is that the last DB schema
change was ~5 years ago and I doubt that most kobo-using services have a
process in place for running migrations around upgrades. I know this is
true at least for Pub.

For that reason, the info is maintained using 0-byte state files. This
is expected to be compatible with all environments without requiring
migrations.