### PR TITLE
ci: drop python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
     env: TOXENV=py27-django18
   - python: "2.7"
     env: TOXENV=py27-django111
-  - python: "3.4"
-    env: TOXENV=py34-django18
   - python: "3.5"
     env: TOXENV=py35-django111
   - python: "3.6"


### PR DESCRIPTION
The python 3.4 config no longer passes apparently due to one of the
dependencies being incompatible with it:

    File "<...>/.tox/py34-django18/lib/python3.4/site-packages/attr/_make.py", line 34, in <module>
      import typing
    ImportError: No module named 'typing'

It could presumably be fixed by pinning affected deps during that
test run. However, I don't think there's any need to support python
3.4 anyway, so let's just drop it.