### PR TITLE
Change ordering of hub tasks in UI [RHELDST-8253]

### DIFF
--- a/kobo/hub/urls/task.py
+++ b/kobo/hub/urls/task.py
@@ -12,7 +12,7 @@ urlpatterns = [
     url(r"^$", TaskListView.as_view(), name="task/index"),
     url(r"^(?P<pk>\d+)/$", TaskDetail.as_view(), name="task/detail"),
     url(r"^running/$", TaskListView.as_view(state=(TASK_STATES["FREE"], TASK_STATES["ASSIGNED"], TASK_STATES["OPEN"]), title=_("Running tasks"), order_by=["id"]), name="task/running"),
-    url(r"^finished/$", TaskListView.as_view(state=(TASK_STATES["CLOSED"], TASK_STATES["INTERRUPTED"], TASK_STATES["CANCELED"], TASK_STATES["FAILED"]), title=_("Finished tasks"), order_by=["-dt_finished", "id"]), name="task/finished"),
+    url(r"^finished/$", TaskListView.as_view(state=(TASK_STATES["CLOSED"], TASK_STATES["INTERRUPTED"], TASK_STATES["CANCELED"], TASK_STATES["FAILED"]), title=_("Finished tasks"), order_by=["-dt_created", "id"]), name="task/finished"),
     url(r"^(?P<id>\d+)/log/(?P<log_name>.+)$", kobo.hub.views.task_log, name="task/log"),
     url(r"^(?P<id>\d+)/log-json/(?P<log_name>.+)$", kobo.hub.views.task_log_json, name="task/log-json"),
 ]


### PR DESCRIPTION
When viewing the finished tasks list, the hub tasks were sorted by the
finished date. This led to the behaviour that the tasks that did not
finish (because they were cancelled) always sorted above all other
tasks and cluttered the finished task listing. We thus change the
ordering to use "dt_created" instead.