### PR TITLE
Improve Django 4.x compatibility

### DIFF
--- a/kobo/django/auth/models.py
+++ b/kobo/django/auth/models.py
@@ -1,10 +1,12 @@
 import re
 from django.db import models
 from django.core import validators
-from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, UserManager
 from django.core.mail import send_mail
 from django.utils import timezone
+
+from kobo.django.compat import gettext_lazy as _
+
 
 MAX_LENGTH = 255
 

--- a/kobo/django/compat.py
+++ b/kobo/django/compat.py
@@ -1,0 +1,17 @@
+try:
+    # Ancient case: ugettext is the unicode-aware variant
+    from django.utils.translation import ugettext_lazy as gettext_lazy
+except ImportError:
+    # Modern (py3-only) case
+    from django.utils.translation import gettext_lazy
+
+
+try:
+    # Ancient case: force_text is the unicode-aware variant
+    from django.utils.encoding import force_text as force_str
+except:
+    # Modern (py3-only) case
+    from django.utils.encoding import force_str
+
+
+__all__ = ["gettext_lazy", "force_str"]

--- a/kobo/django/fields.py
+++ b/kobo/django/fields.py
@@ -3,7 +3,6 @@ from copy import copy
 import json
 import six
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
 from django.core import exceptions
 from django.utils.text import capfirst
 from django.forms.widgets import Select
@@ -11,6 +10,8 @@ from django.forms.fields import CallableChoiceIterator
 
 import kobo.django.forms
 from kobo.types import StateEnum
+from kobo.django.compat import gettext_lazy as _
+
 
 '''
 StateEnumField

--- a/kobo/django/forms.py
+++ b/kobo/django/forms.py
@@ -8,14 +8,14 @@ except ImportError:
 
 import django.forms.fields
 from django.core.exceptions import ValidationError
-from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.html import conditional_escape
-from django.utils.translation import ugettext_lazy as _
 try:
     from django.forms.utils import flatatt
 except ImportError:
     from django.forms.util import flatatt
+
+from kobo.django.compat import gettext_lazy as _, force_str
 
 
 class StateChoiceFormField(django.forms.fields.TypedChoiceField):
@@ -52,7 +52,7 @@ class JSONWidget(django.forms.widgets.Textarea):
             value = json.dumps(value)
 
         return mark_safe(u'<textarea%s>%s</textarea>' % (flatatt(final_attrs),
-                conditional_escape(force_text(value))))
+                conditional_escape(force_str(value))))
 
 
 class JSONFormField(django.forms.fields.CharField):

--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -23,13 +23,14 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import models, connection, transaction
-from django.utils.translation import ugettext_lazy as _
 from django.db.models.signals import post_delete
 import six
 
 import kobo.django.fields
 from kobo.client.constants import TASK_STATES, FINISHED_STATES, FAILED_STATES
 from kobo.shortcuts import random_string, read_from_file, save_to_file, run
+from kobo.django.compat import gettext_lazy as _
+
 
 LOG_BUFFER_SIZE = 2**20
 

--- a/kobo/hub/urls/arch.py
+++ b/kobo/hub/urls/arch.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
 
-from django.utils.translation import ugettext_lazy as _
 from django.conf.urls import url
 from kobo.django.views.generic import ExtraListView
 from kobo.hub.views import ArchDetailView
 from kobo.hub.models import Arch
+from kobo.django.compat import gettext_lazy as _
+
 
 urlpatterns = [
     url(r"^$", ExtraListView.as_view(

--- a/kobo/hub/urls/task.py
+++ b/kobo/hub/urls/task.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 
-from django.utils.translation import ugettext_lazy as _
 from django.conf.urls import url
 from kobo.hub.models import TASK_STATES
 from kobo.hub.views import TaskListView, TaskDetail
 import kobo.hub.views
+from kobo.django.compat import gettext_lazy as _
 
 
 urlpatterns = [

--- a/kobo/hub/urls/user.py
+++ b/kobo/hub/urls/user.py
@@ -3,9 +3,9 @@
 
 from django.contrib.auth import get_user_model
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
 from kobo.django.views.generic import ExtraListView
 from kobo.hub.views import UserDetailView
+from kobo.django.compat import gettext_lazy as _
 
 
 urlpatterns = [

--- a/kobo/hub/urls/worker.py
+++ b/kobo/hub/urls/worker.py
@@ -2,9 +2,9 @@
 
 
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
 from kobo.django.views.generic import ExtraListView, ExtraDetailView
 from kobo.hub.models import Worker
+from kobo.django.compat import gettext_lazy as _
 
 
 urlpatterns = [

--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -23,12 +23,13 @@ else:
 from django.http import HttpResponse, StreamingHttpResponse, HttpResponseForbidden
 from django.shortcuts import render, get_object_or_404
 from django.template import RequestContext
-from django.utils.translation import ugettext_lazy as _
 from django.views.generic import RedirectView
 
 from kobo.hub.models import Arch, Channel, Task
 from kobo.hub.forms import TaskSearchForm
 from kobo.django.views.generic import ExtraDetailView, SearchView
+from kobo.django.compat import gettext_lazy as _
+
 
 # max log size returned in HTML-embedded view
 HTML_LOG_MAX_SIZE = getattr(settings, "HTML_LOG_MAX_SIZE", (1024 ** 2) * 2)


### PR DESCRIPTION
Django 4 removed some functionality which was deprecated since
Django 3. Update to cope with it.

Since this project still attempts to support python2, we figure out at
import time whether we're on an ancient or modern runtime.