### PR TITLE
Add custom user to the admin page

### DIFF
--- a/kobo/django/auth/admin.py
+++ b/kobo/django/auth/admin.py
@@ -1,1 +1,9 @@
 from django.contrib.auth.admin import *
+import django.contrib.admin as admin
+from kobo.django.django_version import django_version_ge
+
+from kobo.django.auth.models import *
+
+# users are not displayed on admin page since migrations were introduced
+if django_version_ge("1.9.0"):
+    admin.site.register(User, UserAdmin)


### PR DESCRIPTION
As kobo has its own user implementation, its model doesn't get added to
the admin page automatically. Register the user model so that it can be
modified via the admin page. This only affects newer versions of Django.