### PR TITLE
Ensure LoggingThread fatal errors are logged

### DIFF
--- a/kobo/worker/taskmanager.py
+++ b/kobo/worker/taskmanager.py
@@ -389,7 +389,7 @@ class TaskManager(kobo.log.LoggingBase):
         task = TaskClass(hub, self.conf, task_info["id"], task_info["args"])
 
         # redirect stdout and stderr
-        thread = kobo.worker.logger.LoggingThread(hub, task_info["id"])
+        thread = kobo.worker.logger.LoggingThread(hub, task_info["id"], logger=self)
         sys.stdout = kobo.worker.logger.LoggingIO(open(os.devnull, "w"), thread)
         sys.stderr = sys.stdout
         thread.start()


### PR DESCRIPTION
When a task runs, LoggingThread is responsible for sending all task logs
to hub via XML-RPC. The handling of errors during this process was:

1) if an XML-RPC fault: retry an unlimited amount of times

2) if anything else: thread silently exits and logs stop forever

This commit aims to improve the behavior in case (2). If the
LoggingThread is about to die (which does happen sometimes in
practice), we should at least try logging the relevant exception to the
worker's local log file.

This relates to issue #60 which suggests that case (2) should also
retry. That might still make sense, but I'm reluctant to have this retry
on all kinds of exceptions without first understanding what exceptions
can be hit in practice. So, let's first fix up the logging, then maybe
go back and adjust retry behavior later based on what we find.