### PR TITLE
Create URLs for OIDC-based authentication

### DIFF
--- a/kobo/hub/urls/auth.py
+++ b/kobo/hub/urls/auth.py
@@ -9,6 +9,7 @@ if django_version_ge('1.11.0'):
     urlpatterns = [
         url(r"^login/$", kobo.hub.views.LoginView.as_view(), name="auth/login"),
         url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
+        url(r"^oidclogin/$", kobo.hub.views.oidclogin, name="auth/oidclogin"),
         url(r'^logout/$', kobo.hub.views.LogoutView.as_view(), name="auth/logout"),
     ]
 
@@ -16,5 +17,6 @@ else:
     urlpatterns = [
         url(r"^login/$", kobo.hub.views.login, name="auth/login"),
         url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
+        url(r"^oidclogin/$", kobo.hub.views.oidclogin, name="auth/oidclogin"),
         url(r'^logout/$', kobo.hub.views.logout, name="auth/logout"),
     ]

--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -274,3 +274,12 @@ def krb5login(request, redirect_field_name=REDIRECT_FIELD_NAME):
         redirect_to = reverse("home/index")
     return RedirectView.as_view(url=redirect_to, permanent=True)(request)
 
+def oidclogin(request):
+    middleware = 'kobo.django.auth.middleware.LimitedRemoteUserMiddleware'
+    if django_version_ge('1.10.0'):
+        middleware_setting = settings.MIDDLEWARE
+    else:
+        middleware_setting = settings.MIDDLEWARE_CLASSES
+    if middleware not in middleware_setting:
+        raise ImproperlyConfigured("oidclogin view requires '%s' middleware installed" % middleware)
+    return RedirectView.as_view(url=reverse("home/index"), permanent=False)(request)


### PR DESCRIPTION
OIDC-based authentication works similiarly to Kerberos, where a URL has
to be protected by a web server's authentication module, which upon
successful authentication sets the REMOTE_USER environment variable.
This variable is then used by Django to log the user in, as described
in[1]. A difference is that OIDC requires two URLs to be protected by a
web server: URL accessed by the user, and a redirected "vanity url". The
solution was verified to work with Apache and mod_auth_openidc[2].

The flow can be roughly described as follows:
- User accesses the <hostname>/auth/oidclogin/ endpoint protected by
  mod_auth_openidc
- Denied access initiates the authentication
- OIDC auth accesses the <hostname>/auth/oidclogin/redirect/ URL during
  authentication (vanity URL set as OIDCRedirectURI)
- Successful auth ends at URL <hostname>/auth/oidclogin/, where it sets
  the REMOTE_USER variable
- Django's middleware and backend logs the user in
- <hostname>/auth/oidclogin/ can now be accessed, and automatically
  redirects the user to the homepage.

A small limitation was introduced: URL parameters in the protected URL
cannot be used with OIDC auth, as the auth server itself attempts to
interpret them, causing 500 errors. Login normally uses the "next"
parameter, denoting where to redirect the user after a sucessful login
(URL where the login was clicked). As this argument cannot be passed for
OIDC auth, login will always redirect the user to the homepage.

Another small change from Kerberos auth is that a 302 (temporary)
redirect has to be used on the login URL, because 301 would be cached by
the browser and used on subsequent login attempts. This would
effectively break the login, as protected endpoint would not be
used directly.

[1] https://docs.djangoproject.com/en/4.0/howto/auth-remote-user/
[2] https://github.com/zmartzone/mod_auth_openidc