### PR TITLE
Adding xml-rpc exception to retry decorator

### DIFF
--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -630,7 +630,8 @@ def retry_request_decorator(transport_class):
                     return result
                 except KeyboardInterrupt:
                     raise
-                except (socket.error, socket.herror, socket.gaierror, socket.timeout, httplib.CannotSendRequest) as ex:
+                except (socket.error, socket.herror, socket.gaierror, socket.timeout,
+                        httplib.CannotSendRequest, xmlrpclib.ProtocolError) as ex:
                     if i >= self.retry_count:
                         raise
                     retries_left = self.retry_count - i


### PR DESCRIPTION
XML-RPC Protocol Error exceptions were not being caught by the retry decorator, so these errors weren't getting retried. Just need to add in the specific exception into the list of retried exceptions. 