### PR TITLE
Implement OIDC-based authentication for clients

### DIFF
--- a/kobo/admin/templates/client/__project_name__.conf
+++ b/kobo/admin/templates/client/__project_name__.conf
@@ -3,7 +3,7 @@
 # Hub XML-RPC address.
 HUB_URL = "http://localhost:8000/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
 AUTH_METHOD = ""
 
 # Username and password
@@ -31,6 +31,15 @@ AUTH_METHOD = ""
 
 # Kerberos proxy users.
 #KRB_PROXY_USERS = ""
+
+# OIDC public client used to verify the user
+#OIDC_CLIENT = "example-client"
+
+# Application redirect URL used to complete the OIDC authentication
+#OIDC_REDIRECT = "https://example-app.com"
+
+# Authentication URL used to verify with OIDC
+#OIDC_BASE_URL = "https://example-auth-url.com"
 
 # Enables XML-RPC verbose flag
 DEBUG_XMLRPC = 0

--- a/kobo/admin/templates/worker/__project_name__.conf
+++ b/kobo/admin/templates/worker/__project_name__.conf
@@ -3,7 +3,7 @@
 # Hub XML-RPC address.
 HUB_URL = "http://localhost.localdomain:8000/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
 AUTH_METHOD = ""
 
 # Username and password
@@ -46,6 +46,15 @@ MAX_JOBS = 10
 
 # Task manager sleep time between polls.
 SLEEP_TIME = 20
+
+# OIDC public client used to verify the user
+#OIDC_CLIENT = "example-client"
+
+# Application redirect URL used to complete the OIDC authentication
+#OIDC_REDIRECT = "https://example-app.com"
+
+# Authentication URL used to verify with OIDC
+#OIDC_BASE_URL = "https://example-auth-url.com"
 
 # Enables XML-RPC verbose flag
 DEBUG_XMLRPC = 0

--- a/kobo/client/default.conf
+++ b/kobo/client/default.conf
@@ -1,7 +1,7 @@
 # Hub xml-rpc address.
 HUB_URL = "https://localhost/hub/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
 AUTH_METHOD = "krbv"
 
 # Username and password
@@ -29,3 +29,12 @@ AUTH_METHOD = "krbv"
 
 # Kerberos proxy users.
 #KRB_PROXY_USERS = ""
+
+# OIDC public client used to verify the user
+#OIDC_CLIENT = "example-client"
+
+# Application redirect URL used to complete the OIDC authentication
+#OIDC_REDIRECT = "https://example-app.com"
+
+# Authentication URL used to verify with OIDC
+#OIDC_BASE_URL = "https://example-auth-url.com"

--- a/kobo/hub/xmlrpc/auth.py
+++ b/kobo/hub/xmlrpc/auth.py
@@ -23,6 +23,7 @@ __all__ = (
     "login_krbv",
     "login_password",
     "login_worker_key",
+    "login_oidc",
     "logout",
 )
 

--- a/kobo/worker/default.conf
+++ b/kobo/worker/default.conf
@@ -44,3 +44,12 @@ MAX_JOBS = 10
 
 # Task manager sleep time between polls.
 SLEEP_TIME = 20
+
+# OIDC public client used to verify the user
+#OIDC_CLIENT = "example-client"
+
+# Application redirect URL used to complete the OIDC authentication
+#OIDC_REDIRECT = "https://example-app.com"
+
+# Authentication URL used to verify with OIDC
+#OIDC_BASE_URL = "https://example-auth-url.com"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,6 @@ Django
 koji
 requests
 requests_gssapi
+requests-kerberos
+jwcrypto
+requests_cache

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -85,3 +85,6 @@ if VERSION[0:3] >= (1, 9, 0):
 ROOT_URLCONF = 'tests.hub_urls'
 
 STATIC_URL = os.path.join(os.path.dirname(kobo.__file__), "hub", "static") + '/'
+
+OIDC_PUBLIC_KEY_URL = "https://key-url.com/"
+OIDC_PUBLIC_CLIENT_ID = "some-client"


### PR DESCRIPTION
The client authenticates with the authentication server with Kerberos,
and once authenticated receives a JWT from the server. Then, client
sends the JWT to the hub, which uses it to authenticate the user.
The hub tries to decode the JWT with a public key received from the
auth server, and verify that the JWT is not expired and that it was
generated for the correct app. If everything checks out, the client
is logged in and is able to perform restricted actions via the HubProxy.

Hub uses cache so that it doesn't have to query the auth server for the
public key in every request. The cache expires after 1 day.

A limitation of this solution is that the CLI client has to query the auth
server for each action it performs, which may introduce significant
overhead to the server. As far as I know, large amounts of commands done
via a CLI in a short time timespan is not a typical use-case, so the
introduction of OIDC auth shouldn't cause any issues for the auth
server.