### PR TITLE
Implement OIDC-based client authentication

### DIFF
--- a/kobo/admin/templates/client/__project_name__.conf
+++ b/kobo/admin/templates/client/__project_name__.conf
@@ -3,7 +3,7 @@
 # Hub XML-RPC address.
 HUB_URL = "http://localhost:8000/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
 AUTH_METHOD = ""
 
 # Username and password

--- a/kobo/admin/templates/worker/__project_name__.conf
+++ b/kobo/admin/templates/worker/__project_name__.conf
@@ -3,7 +3,7 @@
 # Hub XML-RPC address.
 HUB_URL = "http://localhost.localdomain:8000/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
 AUTH_METHOD = ""
 
 # Username and password

--- a/kobo/client/default.conf
+++ b/kobo/client/default.conf
@@ -1,7 +1,7 @@
 # Hub xml-rpc address.
 HUB_URL = "https://localhost/hub/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
 AUTH_METHOD = "krbv"
 
 # Username and password

--- a/kobo/worker/default.conf
+++ b/kobo/worker/default.conf
@@ -1,7 +1,7 @@
 # Hub xml-rpc address.
 HUB_URL = "https://localhost/hub/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
 AUTH_METHOD = "krbv"
 
 # Username and password

--- a/tests/test_hubproxy.py
+++ b/tests/test_hubproxy.py
@@ -132,6 +132,7 @@ def test_login_gssapi_krb_opts(requests_session):
     # server principal
     mock_auth.assert_called_once_with(
         creds=mock_creds.return_value,
+        mutual_authentication=2,
         target_name=gssapi.Name(
             "SVC/hub.example.com@REALM.EXAMPLE.COM", gssapi.NameType.kerberos_principal
         ),


### PR DESCRIPTION
Authentication is performed by querying the hub endpoint protected by
mod_auth_openidc. OIDC authenticates the user with their Kerberos
ticket, and redirects back to hub. Django then recognizes REMOTE_USER
set by mod_auth_openidc and logs the user in. THe user's login is
captured in the session's cookiejar. After login is complete, the cookie
is added to the XMLRPC transport object, which uses it to authenticate
when making requests to hub via XMLRPC.