### PR TITLE
Add option to use a custom task manager class

### DIFF
--- a/kobo/worker/taskmanager.py
+++ b/kobo/worker/taskmanager.py
@@ -46,6 +46,7 @@ Struct: task_info
 
 from __future__ import absolute_import
 
+import abc
 import datetime
 import errno
 import os
@@ -87,7 +88,30 @@ class TaskContainer(PluginContainer):
     pass
 
 
-class TaskManager(kobo.log.LoggingBase):
+@six.add_metaclass(abc.ABCMeta)
+class TaskManagerBase(kobo.log.LoggingBase):
+    """Abstract class for a task manager defining which methods must be implemented."""
+    @abc.abstractmethod
+    def update_worker_info(self):
+        pass
+
+    @abc.abstractmethod
+    def update_tasks(self):
+        pass
+    
+    @abc.abstractmethod
+    def get_next_task(self):
+        pass
+    
+    @abc.abstractmethod
+    def sleep(self):
+        pass
+    
+    @abc.abstractmethod
+    def shutdown(self):
+        pass
+
+class TaskManager(TaskManagerBase):
     """Task manager takes and executes new tasks."""
 
     def __init__(self, conf, logger=None, **kwargs):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -234,6 +234,7 @@ class TestMain(unittest.TestCase):
                         conf=conf,
                         daemon_pid_file='/tmp/pid',
                         foreground=False,
+                        task_manager_class=None,
                     )
 
     def test_main_foreground_command(self):
@@ -248,7 +249,11 @@ class TestMain(unittest.TestCase):
                         exit_mock.assert_not_called()
                         kill_mock.assert_not_called()
                         daemonize_mock.assert_not_called()
-                        main_loop_mock.assert_called_once_with(conf, foreground=True)
+                        main_loop_mock.assert_called_once_with(
+                            conf, 
+                            foreground=True, 
+                            task_manager_class=None
+                        )
 
     def test_main_pid_file_command(self):
         with patch.object(main.kobo.process, 'daemonize') as daemonize_mock:
@@ -263,6 +268,7 @@ class TestMain(unittest.TestCase):
                         conf={},
                         daemon_pid_file='/tmp/pid',
                         foreground=False,
+                        task_manager_class=None,
                     )
 
     def test_main_kill_command(self):


### PR DESCRIPTION
The class is passed a parameter to the main function. If a parameter is
passed, this class is used as a task manager instead of the default one.
Base class declaring which methods must the task manager implement was
added as well. These methods are called by the main loop and govern the
workflow of the task manager.