### PR TITLE
shortcuts.run: Use backslashreplace

### DIFF
--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -287,7 +287,7 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
     # new args added in py3 for Popen
     text = kwargs.get('text', False)
     encoding = kwargs.get('encoding', None)
-    errors = kwargs.get('errors', None)
+    errors = kwargs.get('errors', 'backslashreplace')
 
     # any of these args is passed, text mode will be enabled.
     is_text_mode = any([universal_newlines, text, encoding, errors])


### PR DESCRIPTION
If `errors` is `None`, the default data-to-text decoding error handler is `'strict'`. This makes the user code to fail if the stream contains a byte sequence that cannot be converted to text under selected encoding. By setting `errors='backslashreplace'` such a sequence of bytes will be replaced by escape sequences instead of raising the exception.

Context: As a `kobo` consumers (covscan), we agree that it will be better for us to have this change in `kobo` instead of adding `errors='backslashreplace'` to many places in our code or implementing a wrapper and backporting the patches to production branches.