### PR TITLE
Decode XMLRPC chunk regardless of its type

### DIFF
--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -695,12 +695,11 @@ def decode_xmlrpc_chunk(chunk_start, chunk_len, chunk_checksum, encoded_chunk, w
 
     chunk_start = int(chunk_start)
     chunk_len = int(chunk_len)
-    decode_func = base64.decodebytes if hasattr(base64, "decodebytes") else base64.decodestring
 
     if isinstance(encoded_chunk, xmlrpclib.Binary):
-        chunk = decode_func(encoded_chunk.data)
+        chunk = base64.b64decode(encoded_chunk.data)
     else:
-        chunk = decode_func(encoded_chunk)
+        chunk = base64.b64decode(encoded_chunk)
 
     if chunk_len not in (-1, len(chunk)):
         raise ValueError("Chunk length doesn't match.")


### PR DESCRIPTION
Currently, the decode function is decided based on the
Python version (decodestring for PY2, decodebytes for PY3). This
generally works, since chunk has bytes type on  Python 3
and str type on Python 2. However, if the XMLRPC client runs on Python
2 and the server runs on Python 3, the chunk will have the str type,
causing the decodebytes function to fail. Replace it instead with the
b64decode function, which is available since Python 2.4 and doesn't care
about the type of its input.