### PR TITLE
Addressing bandit findings and add bandit [RHELDST-12089]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
           py39-django3,
           py310-django2,
           py310-django3,
+          py39-bandit,
         ]
 
     # Use GitHub's Linux Docker host

--- a/kobo/client/commands/cmd_watch_log.py
+++ b/kobo/client/commands/cmd_watch_log.py
@@ -59,8 +59,11 @@ class Watch_Log(ClientCommand):
         # altered it should work.
         url = self.conf['HUB_URL'].replace('/xmlrpc', '') + '/task/%d/log-json/%s?offset=%d'
         offset = 0
+        assert url.startswith(("http:", "https:"))
         while True:
-            data = json.loads(urllib2.urlopen(url % (task_id, kwargs['type'], offset)).read())
+            data = json.loads(
+                urllib2.urlopen(url % # nosec B310
+                                (task_id, kwargs['type'], offset)).read())
             if data['content']:
                 sys.stdout.write(data['content'])
                 sys.stdout.flush()

--- a/kobo/django/forms.py
+++ b/kobo/django/forms.py
@@ -8,8 +8,8 @@ except ImportError:
 
 import django.forms.fields
 from django.core.exceptions import ValidationError
-from django.utils.safestring import mark_safe
-from django.utils.html import conditional_escape
+from django.utils.html import format_html
+
 try:
     from django.forms.utils import flatatt
 except ImportError:
@@ -51,8 +51,8 @@ class JSONWidget(django.forms.widgets.Textarea):
         if not isinstance(value, six.string_types):
             value = json.dumps(value)
 
-        return mark_safe(u'<textarea%s>%s</textarea>' % (flatatt(final_attrs),
-                conditional_escape(force_str(value))))
+        return format_html(u'<textarea{}>{}</textarea>',
+                           flatatt(final_attrs), force_str(value))
 
 
 class JSONFormField(django.forms.fields.CharField):

--- a/kobo/django/menu/__init__.py
+++ b/kobo/django/menu/__init__.py
@@ -99,7 +99,7 @@ if django_version_ge('1.10.0'):
     from django.urls import reverse
 else:
     from django.core.urlresolvers import reverse
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 try:
     from django.utils.encoding import smart_unicode as smart_text
@@ -157,11 +157,11 @@ class MenuItem(object):
 
     def __str__(self):
         if self.title == "":
-            return mark_safe(u"<li class='divider'></li>")
+            return format_html(u"<li class='divider'></li>")
         result = ""
         if self.items:
             result = u"<ul>%s</ul>" % u"".join([six.text_type(i) for i in self.items])
-        return mark_safe(u"<li>%s%s</li>" % (self.as_a(), result))
+        return format_html(u"<li>%s%s</li>", self.as_a(), result)
 
     @property
     def url(self):
@@ -184,7 +184,7 @@ class MenuItem(object):
         else:
             result = six.text_type(self.title)
 
-        return mark_safe(result)
+        return format_html(result)
 
     @property
     def items(self):

--- a/kobo/http.py
+++ b/kobo/http.py
@@ -118,7 +118,7 @@ class POSTTransport(object):
         content_type = "multipart/form-data; boundary=" + self._boundary
 
         if secure:
-            request = httplib.HTTPSConnection(host, port)
+            request = httplib.HTTPSConnection(host, port) # nosec B309
         else:
             request = httplib.HTTPConnection(host, port)
 

--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -323,7 +323,7 @@ def run(cmd, show_cmd=False, stdout=False, logfile=None, can_fail=False, workdir
         if stdin_data is not None:
             stdin = subprocess.PIPE
 
-        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, # nosec B602
                                 stderr=subprocess.STDOUT, stdin=stdin,
                                 cwd=workdir, **kwargs)
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -12,7 +12,7 @@ from kobo.decorators import log_traceback
 
 class TestDecoratorsModule(unittest.TestCase):
     def setUp(self):
-        self.tmp_file = tempfile.mktemp()
+        fd, self.tmp_file = tempfile.mkstemp()
 
     def tearDown(self):
         os.remove(self.tmp_file)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -155,12 +155,12 @@ class TestMainLoop(unittest.TestCase):
                     with patch.object(main.sys, 'exit') as exit_mock:
                         main.main_loop({
                             'max_runs': max_runs,
-                            'LOG_FILE': '/tmp/log.txt',
+                            'LOG_FILE': '/test/log.txt',
                         }, foreground=False)
 
                         log_mock.add_rotating_file_logger.assert_called_once_with(
                             self.task_manager._logger,
-                            '/tmp/log.txt',
+                            '/test/log.txt',
                             log_level=10,
                         )
 
@@ -190,12 +190,12 @@ class TestMainLoop(unittest.TestCase):
                     with patch.object(main.sys, 'exit') as exit_mock:
                         main.main_loop({
                             'max_runs': max_runs,
-                            'LOG_FILE': '/tmp/log.txt',
+                            'LOG_FILE': '/test/log.txt',
                         }, foreground=True)
 
                         log_mock.add_rotating_file_logger.assert_called_once_with(
                             self.task_manager._logger,
-                            '/tmp/log.txt',
+                            '/test/log.txt',
                             log_level=10,
                         )
 
@@ -220,7 +220,7 @@ class TestMainLoop(unittest.TestCase):
 class TestMain(unittest.TestCase):
 
     def test_main_with_no_commands(self):
-        conf = {'PID_FILE': '/tmp/pid'}
+        conf = {'PID_FILE': '/test/pid'}
 
         with patch.object(main.kobo.process, 'daemonize') as daemonize_mock:
             with patch.object(main.os, 'kill') as kill_mock:
@@ -232,13 +232,13 @@ class TestMain(unittest.TestCase):
                     daemonize_mock.assert_called_once_with(
                         main.main_loop,
                         conf=conf,
-                        daemon_pid_file='/tmp/pid',
+                        daemon_pid_file='/test/pid',
                         foreground=False,
                         task_manager_class=None,
                     )
 
     def test_main_foreground_command(self):
-        conf = {'PID_FILE': '/tmp/pid'}
+        conf = {'PID_FILE': '/test/pid'}
 
         with patch('kobo.worker.main.main_loop') as main_loop_mock:
             with patch.object(main.kobo.process, 'daemonize') as daemonize_mock:
@@ -259,14 +259,14 @@ class TestMain(unittest.TestCase):
         with patch.object(main.kobo.process, 'daemonize') as daemonize_mock:
             with patch.object(main.os, 'kill') as kill_mock:
                 with patch.object(main.sys, 'exit') as exit_mock:
-                    main.main({}, argv=['--pid-file', '/tmp/pid'])
+                    main.main({}, argv=['--pid-file', '/test/pid'])
 
                     exit_mock.assert_not_called()
                     kill_mock.assert_not_called()
                     daemonize_mock.assert_called_once_with(
                         main.main_loop,
                         conf={},
-                        daemon_pid_file='/tmp/pid',
+                        daemon_pid_file='/test/pid',
                         foreground=False,
                         task_manager_class=None,
                     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -687,7 +687,7 @@ class TestTaskLog(django.test.TransactionTestCase):
     def test_list_walks_task_dir(self):
         task = PropertyMock(
             id=100,
-            task_dir=Mock(return_value=tempfile.tempdir),
+            task_dir=Mock(return_value="/test"),
             spec=['id', 'task_dir'],
         )
 
@@ -695,12 +695,12 @@ class TestTaskLog(django.test.TransactionTestCase):
 
         with patch.object(models.os, 'walk') as mock_walk:
             mock_walk.return_value = [
-                ('/tmp', (), ('file1.log.gz', 'file2.log.gz',),),
+                ('/test', (), ('file1.log.gz', 'file2.log.gz',),),
             ]
 
             files = task_log.list
 
-            mock_walk.assert_called_once_with(tempfile.tempdir + '/')
+            mock_walk.assert_called_once_with("/test/")
             self.assertEqual(len(files), 2)
             self.assertEqual(files[0], 'file1.log')
             self.assertEqual(files[1], 'file2.log')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Don't forget to update GA config when changing this
-envlist = {py36, py38, py39, py310}-{django2, django3}
+envlist = {py36, py38, py39, py310}-{django2, django3}, py39-bandit
 skip_missing_interpreters = True
 
 [testenv]
@@ -25,3 +25,7 @@ commands=
     coveralls
 # for testing with python-rpm
 sitepackages = True
+
+[testenv:py39-bandit]
+deps=bandit
+commands=bandit -r . -ll --exclude ./.tox


### PR DESCRIPTION
We're adding in the Bandit scan in order to satisfy the ESS guidline
SEC-APP-REQ-2.

There are two points where nosec have been used that should be noted.
First is the subprocess.Popen in shortcuts.run. While adding Bandit
scan to rcm-pub we discussed this function and concluded it should be
left unchanged. This is because it's widely used and changing it would
outright break many tools which use this library. The other nosec comment is
on HTTPSConnection in http.py. This is because the issue affects old versions
of python 2.7 and python 3.4. I think it would be unlikely for this code to
be used with a vulnerable interpreter, and I've struggled to find other options
for python2. If this should beaddressed and there are actually viable options
I'll happily revist this.
