### PR TITLE
Make kobo compatible with Django 4.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
           py39-django3,
           py310-django2,
           py310-django3,
+          py38-django4,
+          py310-django4,
           py39-bandit,
         ]
 

--- a/kobo/django/auth/__init__.py
+++ b/kobo/django/auth/__init__.py
@@ -1,1 +1,6 @@
-default_app_config = 'kobo.django.auth.apps.AuthConfig'
+from kobo.django.django_version import django_version_ge
+
+if django_version_ge('3.2.0'):
+    pass
+else:
+    default_app_config = 'kobo.django.auth.apps.AuthConfig'

--- a/kobo/django/menu/__init__.py
+++ b/kobo/django/menu/__init__.py
@@ -104,7 +104,7 @@ from django.utils.html import format_html
 try:
     from django.utils.encoding import smart_unicode as smart_text
 except ImportError:
-    from django.utils.encoding import smart_text
+    from django.utils.encoding import smart_str as smart_text
 
 
 __all__ = (
@@ -161,7 +161,7 @@ class MenuItem(object):
         result = ""
         if self.items:
             result = u"<ul>%s</ul>" % u"".join([six.text_type(i) for i in self.items])
-        return format_html(u"<li>%s%s</li>", self.as_a(), result)
+        return format_html(u"<li>%s%s</li>" % (self.as_a(), result))
 
     @property
     def url(self):
@@ -250,8 +250,8 @@ class MenuItem(object):
     def as_li(self):
         """Render menu item as a list item."""
         if not self.title:
-            return mark_safe('<li class="divider"></li>')
-        return mark_safe('<li>%s</li>' % self.as_a())
+            return format_html('<li class="divider"></li>')
+        return format_html('<li>%s</li>' % self.as_a())
 
     def as_bootstrap_navbar_dropdown_menu(self):
         """
@@ -267,7 +267,7 @@ class MenuItem(object):
             sub = '<ul class="dropdown-menu" role="menu">%s</ul>' % sub
             cls = ' class="dropdown"'
 
-        return mark_safe('<li%s>%s%s</li>' % (cls, link, sub))
+        return format_html('<li%s>%s%s</li>' % (cls, link, sub))
 
 
 @python_2_unicode_compatible
@@ -289,7 +289,7 @@ class MainMenu(MenuItem):
 
     def __str__(self):
         """Return menu as printable <ul> list."""
-        return mark_safe(u"<ul>%s</ul>" % "".join([six.text_type(i) for i in self.items]))
+        return format_html(u"<ul>%s</ul>" % "".join([six.text_type(i) for i in self.items]))
 
     def as_bootstrap_navbar_dropdown_menu(self):
         """
@@ -298,7 +298,7 @@ class MainMenu(MenuItem):
         rendered as dropdown menus.
         """
         content = ''.join([i.as_bootstrap_navbar_dropdown_menu() for i in self.items])
-        return mark_safe('<ul class="nav navbar-nav">%s</ul>' % content)
+        return format_html('<ul class="nav navbar-nav">%s</ul>' % content)
 
     def __getattr__(self, name):
         # get specified submenu level in active menu

--- a/kobo/django/upload/urls.py
+++ b/kobo/django/upload/urls.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
-
-from django.conf.urls.defaults import url
+from kobo.django.django_version import django_version_ge
+if django_version_ge("2.0"):
+    from django.urls import re_path as url
+    
+else:
+    from django.conf.urls import url
 import kobo.django.upload.views
 
 

--- a/kobo/django/xmlrpc/views.py
+++ b/kobo/django/xmlrpc/views.py
@@ -69,7 +69,7 @@ XMLRPC_TEMPLATE = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//
   <h2>Details</h2>
   {% for method in method_list %}
     <h3><a name="{{ method.name|lower }}">{{ method.name|escape }}</a></h3>
-    {% ifnotequal method.signature "signatures not supported" %}<strong>Signature: </strong>{{ method.signature|escape }}<br />{% endifnotequal %}
+    {% if method.signature != "signatures not supported" %}<strong>Signature: </strong>{{ method.signature|escape }}<br />{% endif %}
     <pre>{% for line in method.help %}{{ line|escape }}<br />{% endfor %}</pre>
   {% endfor %}
 </body>

--- a/kobo/hub/templates/worker/detail.html
+++ b/kobo/hub/templates/worker/detail.html
@@ -25,7 +25,7 @@
   <tr>
     <th>{% trans "Tasks" %}</th>
     <td>{{ worker.task_count }} / {{ worker.max_tasks }}</td>
-    <td><span class="{% ifnotequal worker.task_count worker.max_tasks %}FREE{% else %}FAILED{% endifnotequal %}">{{ worker.task_count }}</span> / {{ worker.max_tasks }}</td>
+    <td><span class="{% if worker.task_count != worker.max_tasks %}FREE{% else %}FAILED{% endif %}">{{ worker.task_count }}</span> / {{ worker.max_tasks }}</td>
   </tr>
   <tr>
     <th>{% trans "Enabled" %}</th>

--- a/kobo/hub/templates/worker/list_include.html
+++ b/kobo/hub/templates/worker/list_include.html
@@ -14,7 +14,7 @@
     <td>{{ worker.arches.all|join:" " }}</td>
     <td>{% if worker.enabled %}<span class="FREE">{% trans 'YES' %}</span>{% else %}<span class="FAILED">{% trans 'NO' %}</span>{% endif %}</td>
     <td>{% if worker.ready %}<span class="FREE">{% trans 'YES' %}</span>{% else %}<span class="FAILED">{% trans 'NO' %}</span>{% endif %}</td>
-    <td><span class="{% ifnotequal worker.task_count worker.max_tasks %}FREE{% else %}FAILED{% endifnotequal %}">{{ worker.task_count }}</span> / {{ worker.max_tasks }}</td>
+    <td><span class="{% if worker.task_count != worker.max_tasks %}FREE{% else %}FAILED{% endif %}">{{ worker.task_count }}</span> / {{ worker.max_tasks }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/kobo/hub/urls/arch.py
+++ b/kobo/hub/urls/arch.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
-
-from django.conf.urls import url
+from kobo.django.django_version import django_version_ge
+if django_version_ge("2.0"):
+    from django.urls import re_path as url
+    
+else:
+    from django.conf.urls import url
 from kobo.django.views.generic import ExtraListView
 from kobo.hub.views import ArchDetailView
 from kobo.hub.models import Arch

--- a/kobo/hub/urls/auth.py
+++ b/kobo/hub/urls/auth.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
-from django.conf.urls import url
-import kobo.hub.views
 from kobo.django.django_version import django_version_ge
+if django_version_ge("2.0"):
+    from django.urls import re_path as url
+    
+else:
+    from django.conf.urls import url
+import kobo.hub.views
 
 if django_version_ge('1.11.0'):
     urlpatterns = [

--- a/kobo/hub/urls/channel.py
+++ b/kobo/hub/urls/channel.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 
-
-from django.utils.translation import ugettext_lazy as _
-from django.conf.urls import url
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
+from kobo.django.django_version import django_version_ge
+if django_version_ge("2.0"):
+    from django.urls import re_path as url
+    
+else:
+    from django.conf.urls import url
 from kobo.django.views.generic import ExtraListView
 from kobo.hub.views import DetailViewWithWorkers
 from kobo.hub.models import Channel

--- a/kobo/hub/urls/task.py
+++ b/kobo/hub/urls/task.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
 
-from django.conf.urls import url
+from kobo.django.django_version import django_version_ge
+if django_version_ge("2.0"):
+    from django.urls import re_path as url
+    
+else:
+    from django.conf.urls import url
 from kobo.hub.models import TASK_STATES
 from kobo.hub.views import TaskListView, TaskDetail
 import kobo.hub.views

--- a/kobo/hub/urls/user.py
+++ b/kobo/hub/urls/user.py
@@ -2,7 +2,12 @@
 
 
 from django.contrib.auth import get_user_model
-from django.conf.urls import url
+from kobo.django.django_version import django_version_ge
+if django_version_ge("2.0"):
+    from django.urls import re_path as url
+    
+else:
+    from django.conf.urls import url
 from kobo.django.views.generic import ExtraListView
 from kobo.hub.views import UserDetailView
 from kobo.django.compat import gettext_lazy as _

--- a/kobo/hub/urls/worker.py
+++ b/kobo/hub/urls/worker.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
 
-from django.conf.urls import url
+from kobo.django.django_version import django_version_ge
+if django_version_ge("2.0"):
+    from django.urls import re_path as url
+    
+else:
+    from django.conf.urls import url
 from kobo.django.views.generic import ExtraListView, ExtraDetailView
 from kobo.hub.models import Worker
 from kobo.django.compat import gettext_lazy as _

--- a/kobo/hub/xmlrpc/__init__.py
+++ b/kobo/hub/xmlrpc/__init__.py
@@ -1,1 +1,6 @@
-default_app_config = 'xmlrpc.apps.XmlrpcConfig'
+from kobo.django.django_version import django_version_ge
+
+if django_version_ge('3.2.0'):
+    pass
+else:
+    default_app_config = 'xmlrpc.apps.XmlrpcConfig'

--- a/tests/hub_urls.py
+++ b/tests/hub_urls.py
@@ -1,4 +1,10 @@
-from django.conf.urls import url, include
+from kobo.django.django_version import django_version_ge
+if django_version_ge("2.0"):
+    from django.urls import re_path as url
+    from django.urls import include
+    
+else:
+    from django.conf.urls import url, include
 from django.contrib import admin
 from django.http import HttpResponse
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -74,7 +74,7 @@ class TestWorkerMiddleware(unittest.TestCase):
             req = DummyRequest()
             req.user = PropertyMock(username='foo/bar')
 
-            middleware.WorkerMiddleware().process_request(req)
+            middleware.WorkerMiddleware(lambda x: x).process_request(req)
             self.assertIsInstance(req.worker, DummyWorker)
             get_worker_mock.assert_called_once_with(req)
 
@@ -82,4 +82,4 @@ class TestWorkerMiddleware(unittest.TestCase):
         req = DummyRequest()
 
         with self.assertRaises(AssertionError):
-            middleware.WorkerMiddleware().process_request(req)
+            middleware.WorkerMiddleware(lambda x: x).process_request(req)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Don't forget to update GA config when changing this
-envlist = {py36, py38, py39, py310}-{django2, django3}, py39-bandit
+envlist = {py36, py38, py39, py310}-{django2, django3}, {py38, py310}-django4, py39-bandit
 skip_missing_interpreters = True
 
 [testenv]
@@ -10,6 +10,7 @@ deps =
     -rtest-requirements.txt
     django2: Django~=2.2.0  # Django 2 LTS (EOL 4/2022)
     django3: Django~=3.2.0  # Django 3 LTS (EOL 4/2024)
+    django4: Django~=4.1.0
 # for testing with python-rpm
 sitepackages = True
 


### PR DESCRIPTION
Following changes were made to ensure compatibility:
- default_app_config is no longer used, since it was deprecated [1]
- The function smart_text() was replaced with smart_str because it was
  removed in Django 4.0 [2]
- django.conf.urls.url() was replaced with django.urls.re_path() because
  it was removed in 4.0 [3][2]
- {% ifnotequal %} was replaced by {% if %} because it was removed in
  4.0 [2]
- ugettext_lazy was replaced with gettext_lazy because it was removed in
  4.0 [2]
- A no-op lambda function was added as the first argument for
  middleware's __init__ method because it's now required [2]

Also, PR #182 [4] introduced two issues when it changed mark_safe to
format_html:
- It didn't replace all occurrences of mark_safe, and since the import
  of mark_safe was removed, the render attempt always failed with an
  exception.
- It changed how the strings are constructed. This caused all menu
  strings to be displayed as %s%s.
Both issues should be now resolved.

It should be noted that using kobo-django-exporter will cause errors on
Django 4+. It was made compatible with PR #37 [5], but the changes were
never released.

[1] https://docs.djangoproject.com/en/4.1/releases/3.2/#automatic-appconfig-discovery
[2] https://docs.djangoproject.com/en/4.1/releases/4.0/#features-removed-in-4-0
[3] https://docs.djangoproject.com/en/4.1/releases/3.1/#id2
[4] https://github.com/release-engineering/kobo/pull/182
[5] https://github.com/release-engineering/django-kobo-exporter/pull/37

Refers to CLOUDDST-12599