### PR TITLE
Switch from .iteritems to .items in task detail's template

### DIFF
--- a/kobo/hub/templates/task/detail.html
+++ b/kobo/hub/templates/task/detail.html
@@ -16,7 +16,7 @@
   </tr>
   <tr>
     <th>{% trans "Args" %}</th>
-    <td>{% for arg in task.get_args_display.iteritems %}<b>{{ arg.0 }}:</b> {{ arg.1 }}<br />{% endfor %}</td>
+    <td>{% for arg in task.get_args_display.items %}<b>{{ arg.0 }}:</b> {{ arg.1 }}<br />{% endfor %}</td>
   </tr>
   <tr>
     <th>{% trans "Label" %}</th>


### PR DESCRIPTION
If you think this can be performance-critical, there is a way how to add `six.iteritems` into the template but I think that `.items` working with Python 2 and 3 is fine.