### PR TITLE
Fix calculating the number of task's subtasks in new Django versions

### DIFF
--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -592,6 +592,7 @@ class Task(models.Model):
 
     def save(self, *args, **kwargs):
         # save to db to precalculate subtask counts and obtain an ID (on insert) for stdout and traceback
+        super(self.__class__, self).save()
         self.subtask_count = self.subtasks().count()
         super(self.__class__, self).save()
         self.logs.save()


### PR DESCRIPTION
Task's subtasks() method find all tasks whose parent is the current task. The subtask_count field is set before the current task is saved to the DB, meaning that subtasks() method matches all tasks without a parent task, which is not the intended behavior. Fix setting subtask_count by first saving the task to the DB so that subtasks() correctly matches the parent task.

This issue is not present when an old version of Django is used.

Refers to CLOUDDST-16678