### PR TITLE
Make subtask inherit parents priority and make it configurable

### DIFF
--- a/kobo/hub/xmlrpc/worker.py
+++ b/kobo/hub/xmlrpc/worker.py
@@ -234,7 +234,7 @@ def get_awaited_tasks(request, awaited_task_list):
 
 
 @validate_worker
-def create_subtask(request, label, method, args, parent_id):
+def create_subtask(request, label, method, args, parent_id, subtask_priority = None):
     parent_task = Task.objects.get_and_verify(task_id=parent_id, worker=request.worker)
 
     return Task.create_task(
@@ -245,6 +245,7 @@ def create_subtask(request, label, method, args, parent_id):
         parent_id=parent_id,
         arch_name=parent_task.arch.name,
         channel_name=parent_task.channel.name,
+        priority=subtask_priority or parent_task.priority
     )
 
 

--- a/kobo/worker/task.py
+++ b/kobo/worker/task.py
@@ -89,12 +89,12 @@ class TaskBase(Plugin):
     def notification(cls, hub, conf, task_info):
         pass
 
-    def spawn_subtask(self, method, args, label=""):
+    def spawn_subtask(self, method, args, label="", priority = None):
         """Spawn a new subtask."""
         if self.foreground:
             raise RuntimeError("Foreground tasks can't spawn subtasks.")
 
-        subtask_id = self.hub.worker.create_subtask(label, method, args, self.task_id)
+        subtask_id = self.hub.worker.create_subtask(label, method, args, self.task_id, priority)
         self._subtask_list.append(subtask_id)
         return subtask_id
 

--- a/tests/test_taskbase.py
+++ b/tests/test_taskbase.py
@@ -144,7 +144,7 @@ class TestTaskBase(unittest.TestCase):
         ret_id = t.spawn_subtask('method', [], 'label')
         self.assertEqual(ret_id, subtask_id)
 
-        hub.worker.create_subtask.assert_called_once_with('label', 'method', [], task_id)
+        hub.worker.create_subtask.assert_called_once_with('label', 'method', [], task_id, None)
 
     def test_spawn_subtask_foreground_task(self):
         task_info = {'id': 100}


### PR DESCRIPTION
Subtasks should inherit parents priority and it should be possible to change it if needed.