### PR TITLE
cli/Help_RST: fix compatibility with Python 3

### DIFF
--- a/kobo/cli.py
+++ b/kobo/cli.py
@@ -380,7 +380,7 @@ class Help_RST(Command):
             if usage:
                 print(usage, end="\n\n")
 
-            for opt in sorted(parser.option_list, lambda x, y: cmp(str(x), str(y))):
+            for opt in sorted(parser.option_list, key=str):
                 if "-h/--help" in str(opt):
                     continue
                 if opt.nargs:


### PR DESCRIPTION
Fixes:
```
  File "/usr/lib/python3.11/site-packages/kobo/cli.py", line 292, in run
    cmd.run(*cmd_args, **cmd_kwargs)
  File "/usr/lib/python3.11/site-packages/kobo/cli.py", line 383, in run
    for opt in sorted(parser.option_list, lambda x, y: cmp(str(x), str(y))):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sorted expected 1 argument, got 2
```