### PR TITLE
Force UTF-8 encoding in str and bytes functions

### DIFF
--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -3,7 +3,6 @@
 import mimetypes
 import os
 import six
-import locale
 from kobo.django.django_version import django_version_ge
 
 try:
@@ -232,7 +231,7 @@ def task_log_json(request, id, log_name):
         next_poll = LOG_WATCHER_INTERVAL
 
     if six.PY3:
-        content = str(content, encoding=locale.getpreferredencoding())
+        content = str(content, encoding="utf-8")
 
     result = {
         "new_offset": offset + len(content),

--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -14,7 +14,6 @@ import random
 import re
 import hashlib
 import threading
-import locale
 import six
 from six.moves import range
 from six.moves import shlex_quote
@@ -222,7 +221,7 @@ def save_to_file(filename, text, append=False, mode=0o644):
     else:
         fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
     if not isinstance(text, bytes):
-        text = bytes(text, encoding=locale.getpreferredencoding())
+        text = bytes(text, encoding="utf-8")
     os.write(fd, text)
     os.close(fd)
 


### PR DESCRIPTION
Recently, an issue was encountered where locale's getpreferredencoding method incorrectly evaluated the encoding to be 'ascii'. This caused the decoding to fail since the data contained unicode characters. I assume that most modern environments use UTF-8, so the chances of breaking anything are low.

Refers to CLOUDDST-17290