### PR TITLE
Add `--hub` option

### DIFF
--- a/kobo/admin/templates/client@cmd___project_name__.py.template
+++ b/kobo/admin/templates/client@cmd___project_name__.py.template
@@ -28,12 +28,13 @@ class {{ project_name|camel_cmd }}(kobo.client.ClientCommand):
         # optparser output is passed via *args (args) and **kwargs (opts)
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
 
         # if not args:
         #     self.parser.error("please specify at least one argument")
 
         # login to the hub
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
 
         # call hub XML-RPC calls or do whatever you want
         #self.hub.client.some_method(kwargs)

--- a/kobo/cli.py
+++ b/kobo/cli.py
@@ -198,6 +198,7 @@ class CommandOptionParser(optparse.OptionParser):
             command_container=None,
             default_command="help",
             add_username_password_options=False,
+            add_hub_option=False,
             default_profile="",
             configuration_directory="/etc"):
 
@@ -214,6 +215,9 @@ class CommandOptionParser(optparse.OptionParser):
                 ["--username", "specify user"],
                 ["--password", "specify password"]
             )
+
+        if add_hub_option:
+            self._add_opts(["--hub", "specify URL of XML-RPC interface on hub"])
 
         if default_profile:
             self.default_profile = default_profile

--- a/kobo/client/__init__.py
+++ b/kobo/client/__init__.py
@@ -62,8 +62,9 @@ class Add_User(kobo.client.ClientCommand):
     def run(self, *args, **kwargs):
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         # self.hub.client.add_user(...)
 """
 
@@ -99,13 +100,16 @@ class BaseClientCommandContainer(kobo.cli.CommandContainer):
     def __init__(self):
         self.conf = kobo.conf.PyConfigParser()
 
-    def set_hub(self, username=None, password=None):
+    def set_hub(self, username=None, password=None, hub=None):
         if username:
             if password is None:
                 password = kobo.cli.password_prompt(default_value=password)
             self.conf["AUTH_METHOD"] = "password"
             self.conf["USERNAME"] = username
             self.conf["PASSWORD"] = password
+
+        if hub:
+            self.conf["HUB_URL"] = hub
 
         self.hub = HubProxy(conf=self.conf)
 

--- a/kobo/client/commands/cmd_add_user.py
+++ b/kobo/client/commands/cmd_add_user.py
@@ -30,10 +30,11 @@ class Add_User(ClientCommand):
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
         admin = kwargs.pop("admin", False)
         user = args[0]
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         try:
             self.hub.admin.add_user(user, admin)
         except Exception as ex:

--- a/kobo/client/commands/cmd_cancel_tasks.py
+++ b/kobo/client/commands/cmd_cancel_tasks.py
@@ -23,9 +23,10 @@ class Cancel_Tasks(ClientCommand):
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
         tasks = args
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
 
         failed = False
         for task_id in tasks:

--- a/kobo/client/commands/cmd_create_task.py
+++ b/kobo/client/commands/cmd_create_task.py
@@ -43,6 +43,7 @@ class Create_Task(ClientCommand):
     def run(self, *args, **kwargs):
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
 
         task_args = kwargs.get("args", None)
         if task_args != None:
@@ -58,5 +59,5 @@ class Create_Task(ClientCommand):
             if value is None:
                 del kwargs[key]
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         self.hub.client.create_task(kwargs)

--- a/kobo/client/commands/cmd_disable_worker.py
+++ b/kobo/client/commands/cmd_disable_worker.py
@@ -31,8 +31,9 @@ class Disable_Worker(ClientCommand):
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         if kwargs['all']:
             try:
                 workers = self.hub.client.list_workers(True)

--- a/kobo/client/commands/cmd_enable_worker.py
+++ b/kobo/client/commands/cmd_enable_worker.py
@@ -31,8 +31,9 @@ class Enable_Worker(ClientCommand):
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         if kwargs['all']:
             try:
                 workers = self.hub.client.list_workers(True)

--- a/kobo/client/commands/cmd_list_tasks.py
+++ b/kobo/client/commands/cmd_list_tasks.py
@@ -50,6 +50,7 @@ class List_Tasks(ClientCommand):
     def run(self, *args, **kwargs):
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
         verbose = kwargs.pop("verbose", False)
         use_json = kwargs.pop("json", False)
 
@@ -65,7 +66,7 @@ class List_Tasks(ClientCommand):
         if not filters:
             self.parser.error("Use at least one from --free or --running options.")
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         result = sorted(self.hub.client.get_tasks([], filters), key=lambda x: x["id"])
         if use_json:
             print(json.dumps(result, indent=2, sort_keys=True))

--- a/kobo/client/commands/cmd_list_workers.py
+++ b/kobo/client/commands/cmd_list_workers.py
@@ -24,7 +24,8 @@ class List_Workers(ClientCommand):
     def run(self, *args, **kwargs):
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
         show_disabled = kwargs.get("show_disabled", False)
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         print(self.hub.client.list_workers(not show_disabled))

--- a/kobo/client/commands/cmd_resubmit_tasks.py
+++ b/kobo/client/commands/cmd_resubmit_tasks.py
@@ -26,12 +26,13 @@ class Resubmit_Tasks(ClientCommand):
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
         force = kwargs.pop("force", False)
         priority = kwargs.pop("priority", None)
 
         tasks = args
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         resubmitted_tasks = []
         failed = False
         for task_id in tasks:

--- a/kobo/client/commands/cmd_shutdown_worker.py
+++ b/kobo/client/commands/cmd_shutdown_worker.py
@@ -32,9 +32,10 @@ class Shutdown_Worker(ClientCommand):
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
         workers = args
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         for worker in workers:
             try:
                 self.hub.client.shutdown_worker(worker, kill)

--- a/kobo/client/commands/cmd_watch_tasks.py
+++ b/kobo/client/commands/cmd_watch_tasks.py
@@ -20,6 +20,7 @@ class Watch_Tasks(ClientCommand):
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         TaskWatcher.watch_tasks(self.hub, args)

--- a/kobo/client/commands/cmd_worker_info.py
+++ b/kobo/client/commands/cmd_worker_info.py
@@ -28,9 +28,10 @@ class Worker_Info(ClientCommand):
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
         worker_name = args[0]
 
-        self.set_hub(username, password)
+        self.set_hub(username, password, hub)
         result = self.hub.client.get_worker_info(worker_name)
         if kwargs.pop("oneline"):
             print(result)


### PR DESCRIPTION
This PR adds an optional `--hub` option to the client that can be used to override `conf["HUB_URL"]` by the user.