### PR TITLE
Fix remaining Django 3 deprecations

### DIFF
--- a/kobo/django/compat.py
+++ b/kobo/django/compat.py
@@ -1,16 +1,12 @@
-try:
-    # Ancient case: ugettext is the unicode-aware variant
+import six
+
+if six.PY2:
+    # Ancient cases: force_text and ugettext are the unicode-aware variants
     from django.utils.translation import ugettext_lazy as gettext_lazy
-except ImportError:
+    from django.utils.encoding import force_text as force_str
+else:
     # Modern (py3-only) case
     from django.utils.translation import gettext_lazy
-
-
-try:
-    # Ancient case: force_text is the unicode-aware variant
-    from django.utils.encoding import force_text as force_str
-except:
-    # Modern (py3-only) case
     from django.utils.encoding import force_str
 
 

--- a/kobo/hub/urls/channel.py
+++ b/kobo/hub/urls/channel.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-try:
-    from django.utils.translation import ugettext_lazy as _
-except ImportError:
-    from django.utils.translation import gettext_lazy as _
+from kobo.django.compat import gettext_lazy as _
 from kobo.django.django_version import django_version_ge
 if django_version_ge("2.0"):
     from django.urls import re_path as url


### PR DESCRIPTION
Use unicode-aware text function variants only with Python 2 because all functions are unicode-aware with Python 3.

This commit fixes the remaining deprecation warnings emitted by Django 3.