### PR TITLE
Pin bandit version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ Django
 koji
 requests
 requests_gssapi
+bandit==1.7.5; python_version > '3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,5 @@ commands=
 sitepackages = True
 
 [testenv:py39-bandit]
-deps=bandit
+deps=-rtest-requirements.txt
 commands=bandit -r . -ll --exclude ./.tox


### PR DESCRIPTION
    We pin the version of Bandit SAST tool to make the CI tests more
    predictable. If we used the latest version available without pinning it,
    the CI tests could start failing on new Bandit version without any
    changes in our codebase.

    We pin the Bandit version by adding version requirement to test-requirements.txt.