### PR TITLE
Retire python 2 support    [RHELDST-15344]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,5 @@ setup(
     package_data    = package_data,
     scripts         = ["kobo/admin/kobo-admin"],
     install_requires=["six"],
-    python_requires ='>2.6',
+    python_requires ='>=3.6',
 )


### PR DESCRIPTION
"python_requires" is declared with at least">=3.6".