### PR TITLE
tasks: make it possible to interrupt assigned tasks

### DIFF
--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -901,7 +901,7 @@ class Task(models.Model):
     def interrupt_task(self, recursive=True):
         """Set the task state to interrupted."""
         try:
-            self.__lock(self.worker_id, new_state=TASK_STATES["INTERRUPTED"], initial_states=(TASK_STATES["OPEN"], ))
+            self.__lock(self.worker_id, new_state=TASK_STATES["INTERRUPTED"], initial_states=(TASK_STATES["ASSIGNED"], TASK_STATES["OPEN"]))
         except (MultipleObjectsReturned, ObjectDoesNotExist):
             raise Exception("Cannot interrupt task %d, state is %s" % (self.id, self.get_state_display()))
 


### PR DESCRIPTION
Fixes the following traceback when an opened task with an assigned subtask is interrupted.
```
Traceback (most recent call last):
  File "/src/kobo/kobo/hub/models.py", line 904, in interrupt_task
    self.__lock(self.worker_id, new_state=TASK_STATES["INTERRUPTED"], initial_states=(TASK_STATES["OPEN"], ))
  File "/src/kobo/kobo/hub/models.py", line 821, in __lock
    raise ObjectDoesNotExist()
django.core.exceptions.ObjectDoesNotExist
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/src/kobo/kobo/django/xmlrpc/dispatcher.py", line 95, in _marshaled_dispatch
    response = self._dispatch(method, params)
  File "/usr/lib64/python3.6/xmlrpc/server.py", line 405, in _dispatch
    return func(*params)
  File "/src/kobo/kobo/hub/decorators.py", line 22, in _new_func
    return func(request, *args, **kwargs)
  File "/src/osh/hub/osh_xmlrpc/worker.py", line 187, in interrupt_tasks
    response = kobo_interrupt_tasks(request, task_list)
  File "/src/kobo/kobo/hub/decorators.py", line 22, in _new_func
    return func(request, *args, **kwargs)
  File "/src/kobo/kobo/hub/xmlrpc/worker.py", line 112, in interrupt_tasks
    task.interrupt_task(recursive=True)
  File "/usr/lib64/python3.6/contextlib.py", line 52, in inner
    return func(*args, **kwds)
  File "/src/kobo/kobo/hub/models.py", line 910, in interrupt_task
    task.interrupt_task(recursive=True)
  File "/usr/lib64/python3.6/contextlib.py", line 52, in inner
    return func(*args, **kwds)
  File "/src/kobo/kobo/hub/models.py", line 906, in interrupt_task
    raise Exception("Cannot interrupt task %d, state is %s" % (self.id, self.get_state_display()))
Exception: Cannot interrupt task 277867, state is ASSIGNED
```

Moreover, the subtask process would then end-up in a lingering state:
```
2023-05-22 09:18:42 [WARNING ] Lingering task 277867 (pid 2)
```