### PR TITLE
Don't raise an error when a character cannot be encoded/decoded

### DIFF
--- a/kobo/hub/views.py
+++ b/kobo/hub/views.py
@@ -231,7 +231,7 @@ def task_log_json(request, id, log_name):
         next_poll = LOG_WATCHER_INTERVAL
 
     if six.PY3:
-        content = str(content, encoding="utf-8")
+        content = str(content, encoding="utf-8", errors="replace")
 
     result = {
         "new_offset": offset + len(content),

--- a/kobo/shortcuts.py
+++ b/kobo/shortcuts.py
@@ -221,7 +221,7 @@ def save_to_file(filename, text, append=False, mode=0o644):
     else:
         fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
     if not isinstance(text, bytes):
-        text = bytes(text, encoding="utf-8")
+        text = bytes(text, encoding="utf-8", errors="replace")
     os.write(fd, text)
     os.close(fd)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
 mock==2.0.0
 pytest
 pytest-env
-Django
 koji
 requests
 requests_gssapi


### PR DESCRIPTION
An issue was encountered where task logs failed to be decoded, causing an error to be raised. When an unknown character is encountered, replace it with ? instead of raising an error.

Refers to CLOUDDST-18868