### PR TITLE
Add Client Credentials Flow OIDC authentication

### DIFF
--- a/kobo/admin/templates/client/__project_name__.conf
+++ b/kobo/admin/templates/client/__project_name__.conf
@@ -3,7 +3,7 @@
 # Hub XML-RPC address.
 HUB_URL = "http://localhost:8000/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc, token_oidc
 AUTH_METHOD = ""
 
 # Username and password

--- a/kobo/admin/templates/worker/__project_name__.conf
+++ b/kobo/admin/templates/worker/__project_name__.conf
@@ -3,7 +3,7 @@
 # Hub XML-RPC address.
 HUB_URL = "http://localhost.localdomain:8000/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc, token_oidc
 AUTH_METHOD = ""
 
 # Username and password

--- a/kobo/client/default.conf
+++ b/kobo/client/default.conf
@@ -1,7 +1,7 @@
 # Hub xml-rpc address.
 HUB_URL = "https://localhost/hub/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc, token_oidc
 AUTH_METHOD = "krbv"
 
 # Username and password

--- a/kobo/hub/urls/auth.py
+++ b/kobo/hub/urls/auth.py
@@ -14,6 +14,7 @@ if django_version_ge('1.11.0'):
         url(r"^login/$", kobo.hub.views.LoginView.as_view(), name="auth/login"),
         url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
         url(r"^oidclogin/$", kobo.hub.views.oidclogin, name="auth/oidclogin"),
+        url(r"^tokenoidclogin/$", kobo.hub.views.oidclogin, name="auth/tokenoidclogin"),
         url(r'^logout/$', kobo.hub.views.LogoutView.as_view(), name="auth/logout"),
     ]
 
@@ -22,5 +23,6 @@ else:
         url(r"^login/$", kobo.hub.views.login, name="auth/login"),
         url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
         url(r"^oidclogin/$", kobo.hub.views.oidclogin, name="auth/oidclogin"),
+        url(r"^tokenoidclogin/$", kobo.hub.views.oidclogin, name="auth/tokenoidclogin"),
         url(r'^logout/$', kobo.hub.views.logout, name="auth/logout"),
     ]

--- a/kobo/worker/default.conf
+++ b/kobo/worker/default.conf
@@ -1,7 +1,7 @@
 # Hub xml-rpc address.
 HUB_URL = "https://localhost/hub/xmlrpc"
 
-# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc
+# Hub authentication method. Example: krbv, gssapi, password, worker_key, oidc, token_oidc
 AUTH_METHOD = "krbv"
 
 # Username and password


### PR DESCRIPTION
The authentication is primarily for automated use-cases that use service accounts to log in. Client receives the access token from SSO using its ID and secret. It then sends the access token to the hub, which validates it and logs the user in. The newly added tokenidclogin URL is expected to be protected by mod_oauth2 (or analogous for the used web server), which handles the validation and the passing of REMOTE_USER to Django. XML-RPC client uses the sessionid cookie (which ensures that the user is logged in) provided by Django.

Refers to CLOUDDST-18720