### PR TITLE
Make kobo compatible with Django 4.2

### DIFF
--- a/kobo/django/upload/models.py
+++ b/kobo/django/upload/models.py
@@ -58,10 +58,14 @@ class FileUpload(models.Model):
     def save(self, *args, **kwargs):
         if not self.upload_key:
             self.upload_key = random_string(64)
+            if "update_fields" in kwargs:
+                kwargs["update_fields"] = {"upload_key"}.union(kwargs["update_fields"])
         if self.state == UPLOAD_STATES['FINISHED']:
             if FileUpload.objects.filter(state = UPLOAD_STATES['FINISHED'], name = self.name).exclude(id = self.id).count() != 0:
                 # someone created same upload faster
                 self.state = UPLOAD_STATES['FAILED']
+                if "update_fields" in kwargs:
+                    kwargs["update_fields"] = {"state"}.union(kwargs["update_fields"])
         super(FileUpload, self).save(*args, **kwargs)
 
     def delete(self):

--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -210,11 +210,16 @@ class Worker(models.Model):
         self.current_load = sum(( task.weight for task in tasks if not task.waiting ))
         self.ready = self.enabled and (self.current_load < self.max_load and self.task_count < 3*self.max_load)
 
+        if "update_fields" in kwargs:
+                kwargs["update_fields"] = {"task_count", "current_load", "ready"}.union(kwargs["update_fields"])
+
         while not self.worker_key:
             # if worker_key is empty, generate a new one
             key = random_string(64)
             if Worker.objects.filter(worker_key=key).count() == 0:
                 self.worker_key = key
+                if "update_fields" in kwargs:
+                    kwargs["update_fields"] = {"worker_key"}.union(kwargs["update_fields"])
         super(self.__class__, self).save(*args, **kwargs)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     -rtest-requirements.txt
     django2: Django~=2.2.0  # Django 2 LTS (EOL 4/2022)
     django3: Django~=3.2.0  # Django 3 LTS (EOL 4/2024)
-    django4: Django~=4.1.0
+    django4: Django~=4.2.0
 # for testing with python-rpm
 sitepackages = True
 


### PR DESCRIPTION
The only change that was required is the adding of updated fields to update_fields parameter in the custom save methods[1]. Django's get_or_create method now fills the update_fields parameter when calling model's save method. This parameter ensures that only the specified model fields will be updated. If a custom save method modifies additional fields, this would result in them not actually being saved to the DB. So, if save was called with the update_fields parameter, extend it with all the modified fields.

[1] https://docs.djangoproject.com/en/4.2/releases/4.2/#setting-update-fields-in-model-save-may-now-be-required