### PR TITLE
hub: get rid of quirks mode in modern browsers

### DIFF
--- a/kobo/django/xmlrpc/views.py
+++ b/kobo/django/xmlrpc/views.py
@@ -46,8 +46,8 @@ from kobo.django.xmlrpc.dispatcher import DjangoXMLRPCDispatcher
 __all__ = []
 
 
-XMLRPC_TEMPLATE = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+XMLRPC_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Language" content="en-us" />

--- a/kobo/hub/templates/layout.html
+++ b/kobo/hub/templates/layout.html
@@ -1,8 +1,7 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-loose.dtd">
+<!DOCTYPE html>
 {% load static %}
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html lang="en">
 
 <head>
   <title>{{ title }}</title>


### PR DESCRIPTION
Fix the following Firefox warning:
```
This page is in Almost Standards Mode. Page layout may be impacted. For Standards Mode use “<!DOCTYPE html>”.
```
Firefox version: 111.0.1 (64-bit)
See: https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode

```
One or more documents in this page is in Quirks Mode, which will render the affected document(s) with quirks incompatible with the current HTML and CSS specifications.

Quirks Mode exists mostly due to historical reasons. If this is not intentional, you can add or modify the DOCTYPE to be `<!DOCTYPE html>` to render the page in No Quirks Mode.
```