### PR TITLE
Add support for dynamically adding workers through client

### DIFF
--- a/kobo/client/commands/cmd_create_worker.py
+++ b/kobo/client/commands/cmd_create_worker.py
@@ -1,0 +1,35 @@
+import sys
+from xmlrpc.client import Fault
+import json
+
+from kobo.client import ClientCommand
+
+
+class Create_Worker(ClientCommand):
+    """create a worker"""
+    enabled = True
+    admin = True
+
+
+    def options(self):
+        self.parser.usage = "%%prog %s worker_name [worker_name]" % self.normalized_name
+
+    def run(self, *args, **kwargs):
+        if not args:
+            self.parser.error("No worker name specified.")
+
+        username = kwargs.pop("username", None)
+        password = kwargs.pop("password", None)
+        hub = kwargs.pop("hub", None)
+        workers = args
+
+        self.set_hub(username, password, hub)
+        for worker in workers:
+            try:
+                new_worker = self.hub.client.create_worker(worker)
+                print(json.dumps(new_worker))
+            except Fault as ex:
+                print(repr(ex), file=sys.stderr)
+                # Exit on first xmlrpc failure
+                # It's very likely user is not admin
+                raise

--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -309,7 +309,13 @@ class Worker(models.Model):
             self.save()
 
         return self.export()
-
+    @classmethod
+    def create_worker(cls, worker_name):
+        new_worker = Worker()
+        new_worker.name = worker_name
+        # This would automatically generate a worker key
+        new_worker.save()
+        return new_worker
 
 class TaskManager(models.Manager):
     """Custom query manager for Task model."""

--- a/kobo/hub/xmlrpc/client.py
+++ b/kobo/hub/xmlrpc/client.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from kobo.hub import models
 from kobo.django.xmlrpc.decorators import admin_required, login_required
-
+from django.core.exceptions import ObjectDoesNotExist
 
 __all__ = (
     "enable_worker",
@@ -24,6 +24,7 @@ __all__ = (
     "list_workers",
     "create_task",
     "task_url",
+    "create_worker",
 )
 
 
@@ -158,3 +159,15 @@ def task_url(request, task_id):
         server_name = request.META["SERVER_NAME"]
 
     return prefix + server_name + reverse("task/detail", args=[task_id])
+
+@admin_required
+def create_worker(self, worker_name):
+    """create_worker(worker_name): none
+    """
+    # Check if a worker with this name already exists
+    try:
+        existing_worker = models.Worker.objects.get(name=worker_name)
+        return existing_worker
+    except ObjectDoesNotExist:
+        pass
+    return models.Worker.create_worker(worker_name)


### PR DESCRIPTION
Add a new `create-worker` option in client to enable support for adding new workers at runtime through client.