### PR TITLE
Fix assignment of `single_request` variable

### DIFF
--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -523,7 +523,7 @@ class CookieTransport(xmlrpclib.Transport):
         raise xmlrpclib.ProtocolError(host + handler, response.status, response.reason, response.msg)
 
     # override the appropriate request method
-        single_request = _single_request3
+    single_request = _single_request3
 
     def send_headers(self, connection, headers):
         headers.extend(self._cookie_headers)


### PR DESCRIPTION
It should be assigned outside `_single_request3` function. This fixes a regression introduced by 69804b31f5ca157bbc3f6aa76d1072ef99105a83