### PR TITLE
django: remove support for Django 1.10 and older

### DIFF
--- a/kobo/django/auth/admin.py
+++ b/kobo/django/auth/admin.py
@@ -1,9 +1,7 @@
 from django.contrib.auth.admin import *
 import django.contrib.admin as admin
-from kobo.django.django_version import django_version_ge
 
 from kobo.django.auth.models import *
 
 # users are not displayed on admin page since migrations were introduced
-if django_version_ge("1.9.0"):
-    admin.site.register(User, UserAdmin)
+admin.site.register(User, UserAdmin)

--- a/kobo/django/auth/middleware.py
+++ b/kobo/django/auth/middleware.py
@@ -1,11 +1,9 @@
 from django.contrib.auth.middleware import RemoteUserMiddleware
-from kobo.django.django_version import django_version_ge
-if django_version_ge('1.10.0'):
-    from django.utils.deprecation import MiddlewareMixin
+from django.utils.deprecation import MiddlewareMixin
 
 from kobo.django.helpers import call_if_callable
 
-class LimitedRemoteUserMiddleware(RemoteUserMiddleware, MiddlewareMixin if django_version_ge('1.10.0') else object):
+class LimitedRemoteUserMiddleware(RemoteUserMiddleware, MiddlewareMixin):
     '''
     Same behaviour as RemoteUserMiddleware except that it doesn't logout user
     if is already logged in.

--- a/kobo/django/menu/__init__.py
+++ b/kobo/django/menu/__init__.py
@@ -94,11 +94,7 @@ from six import python_2_unicode_compatible
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from kobo.django.django_version import django_version_ge
-if django_version_ge('1.10.0'):
-    from django.urls import reverse
-else:
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.html import format_html
 
 try:

--- a/kobo/django/menu/middleware.py
+++ b/kobo/django/menu/middleware.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from kobo.django.django_version import django_version_ge
-if django_version_ge('1.10.0'):
-    from django.utils.deprecation import MiddlewareMixin
+from django.utils.deprecation import MiddlewareMixin
 
 from kobo.django.menu import menu
 
@@ -22,7 +20,7 @@ class LazyMenu(object):
         return request._cached_menu
 
 
-class MenuMiddleware(MiddlewareMixin if django_version_ge('1.10.0') else object):
+class MenuMiddleware(MiddlewareMixin):
     """
     @summary: Middleware for menu object.
     """

--- a/kobo/django/xmlrpc/auth.py
+++ b/kobo/django/xmlrpc/auth.py
@@ -12,7 +12,6 @@ from django.core.exceptions import PermissionDenied
 from django.contrib.sessions.models import Session
 
 from kobo.django.auth.krb5 import Krb5RemoteUserBackend
-from kobo.django.django_version import django_version_ge
 from kobo.django.helpers import call_if_callable
 
 
@@ -37,10 +36,7 @@ def renew_session(request):
 def login_password(request, username, password):
     """login_password(username, password): session_id"""
     backend = ModelBackend()
-    if django_version_ge('1.11.0'):
-        user = backend.authenticate(None, username, password)
-    else:
-        user = backend.authenticate(username, password)
+    user = backend.authenticate(None, username, password)
     if user is None:
         raise PermissionDenied("Invalid username or password.")
     user.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)
@@ -70,10 +66,7 @@ def login_krbv(request, krb_request, proxy_user=None):
     # remove @REALM
     username = cprinc.name.split("@")[0]
     backend = Krb5RemoteUserBackend()
-    if django_version_ge('1.11.0'):
-        user = backend.authenticate(None, username)
-    else:
-        user = backend.authenticate(username)
+    user = backend.authenticate(None, username)
     if user is None:
         raise PermissionDenied()
     user.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)

--- a/kobo/hub/__init__.py
+++ b/kobo/hub/__init__.py
@@ -5,7 +5,6 @@ import os
 
 from kobo.exceptions import ImproperlyConfigured
 from django.conf import settings
-from kobo.django.django_version import django_version_ge
 
 
 for var in ["XMLRPC_METHODS", "TASK_DIR", "UPLOAD_DIR"]:

--- a/kobo/hub/middleware.py
+++ b/kobo/hub/middleware.py
@@ -2,9 +2,7 @@
 
 from __future__ import absolute_import
 
-from kobo.django.django_version import django_version_ge
-if django_version_ge('1.10.0'):
-    from django.utils.deprecation import MiddlewareMixin
+from django.utils.deprecation import MiddlewareMixin
 
 from .models import Worker
 
@@ -28,7 +26,7 @@ class LazyWorker(object):
         return request._cached_worker
 
 
-class WorkerMiddleware(MiddlewareMixin if django_version_ge('1.10.0') else object):
+class WorkerMiddleware(MiddlewareMixin):
     """Sets a request.worker.
 
     - Worker instance if username exists in database

--- a/kobo/hub/urls/auth.py
+++ b/kobo/hub/urls/auth.py
@@ -9,20 +9,10 @@ else:
     from django.conf.urls import url
 import kobo.hub.views
 
-if django_version_ge('1.11.0'):
-    urlpatterns = [
-        url(r"^login/$", kobo.hub.views.LoginView.as_view(), name="auth/login"),
-        url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
-        url(r"^oidclogin/$", kobo.hub.views.oidclogin, name="auth/oidclogin"),
-        url(r"^tokenoidclogin/$", kobo.hub.views.oidclogin, name="auth/tokenoidclogin"),
-        url(r'^logout/$', kobo.hub.views.LogoutView.as_view(), name="auth/logout"),
-    ]
-
-else:
-    urlpatterns = [
-        url(r"^login/$", kobo.hub.views.login, name="auth/login"),
-        url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
-        url(r"^oidclogin/$", kobo.hub.views.oidclogin, name="auth/oidclogin"),
-        url(r"^tokenoidclogin/$", kobo.hub.views.oidclogin, name="auth/tokenoidclogin"),
-        url(r'^logout/$', kobo.hub.views.logout, name="auth/logout"),
-    ]
+urlpatterns = [
+    url(r"^login/$", kobo.hub.views.LoginView.as_view(), name="auth/login"),
+    url(r"^krb5login/$", kobo.hub.views.krb5login, name="auth/krb5login"),
+    url(r"^oidclogin/$", kobo.hub.views.oidclogin, name="auth/oidclogin"),
+    url(r"^tokenoidclogin/$", kobo.hub.views.oidclogin, name="auth/tokenoidclogin"),
+    url(r'^logout/$', kobo.hub.views.LogoutView.as_view(), name="auth/logout"),
+]

--- a/kobo/hub/xmlrpc/auth.py
+++ b/kobo/hub/xmlrpc/auth.py
@@ -15,7 +15,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from kobo.hub.models import Worker
 from kobo.django.auth.krb5 import Krb5RemoteUserBackend
 from kobo.django.xmlrpc.auth import *
-from kobo.django.django_version import django_version_ge
 
 
 __all__ = (
@@ -36,10 +35,7 @@ def login_worker_key(request, worker_key):
 
     username = "worker/%s" % worker.name
     backend = Krb5RemoteUserBackend()
-    if django_version_ge('1.11.0'):
-        user = backend.authenticate(None, username)
-    else:
-        user = backend.authenticate(username)
+    user = backend.authenticate(None, username)
     if user is None:
         raise PermissionDenied()
     user.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)

--- a/kobo/hub/xmlrpc/client.py
+++ b/kobo/hub/xmlrpc/client.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
-from kobo.django.django_version import django_version_ge
-if django_version_ge('1.10.0'):
-    from django.urls import reverse
-else:
-    from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
+from django.urls import reverse
 
 from kobo.hub import models
 from kobo.django.xmlrpc.decorators import admin_required, login_required

--- a/tests/test_xmlrpc_auth.py
+++ b/tests/test_xmlrpc_auth.py
@@ -7,7 +7,6 @@ from mock import Mock, patch
 
 from kobo.hub.models import Worker
 from kobo.hub.xmlrpc import auth
-from kobo.django.django_version import django_version_ge
 
 from .utils import DjangoRunner
 
@@ -34,10 +33,7 @@ class TestLoginWorker(django.test.TransactionTestCase):
                 session_key = auth.login_worker_key(req, 'key')
 
                 login_mock.assert_called_once_with(req, user)
-        if django_version_ge('1.11.0'):
-            krb_mock.authenticate.assert_called_once_with(None, 'worker/name')
-        else:
-            krb_mock.authenticate.assert_called_once_with('worker/name')
+        krb_mock.authenticate.assert_called_once_with(None, 'worker/name')
         self.assertEqual(session_key, '1234567890')
 
     def test_login_worker_key_valid_worker_invalid_user(self):
@@ -49,10 +45,7 @@ class TestLoginWorker(django.test.TransactionTestCase):
             with self.assertRaises(PermissionDenied):
                 auth.login_worker_key(req, 'key')
 
-        if django_version_ge('1.11.0'):
-            krb_mock.authenticate.assert_called_once_with(None, 'worker/name')
-        else:
-            krb_mock.authenticate.assert_called_once_with('worker/name')
+        krb_mock.authenticate.assert_called_once_with(None, 'worker/name')
 
     def test_login_worker_key_invalid_worker(self):
         req = Mock()


### PR DESCRIPTION
... because these versions are not yet compatible with Python 3.6 which kobo targets.

Related: https://docs.djangoproject.com/en/1.10/faq/install/#what-python-version-can-i-use-with-django