### PR TITLE
worker: do not repeatedly remove already awaited tasks from subtask list

### DIFF
--- a/tests/test_taskbase.py
+++ b/tests/test_taskbase.py
@@ -93,15 +93,15 @@ class TestTaskBase(unittest.TestCase):
         args = []
 
         t = TaskBase(hub, conf, task_id, args)
-        self.assertEqual(len(t._subtask_list), 0)
+        self.assertEqual(len(t._running_subtask_list), 0)
 
         # access directly
-        t._subtask_list.append({'id': 1})
-        self.assertEqual(len(t._subtask_list), 1)
+        t._running_subtask_list.append({'id': 1})
+        self.assertEqual(len(t._running_subtask_list), 1)
 
         # copy to prevent modification
         t.subtask_list.append({'id': 2})
-        self.assertEqual(len(t._subtask_list), 1)
+        self.assertEqual(len(t._running_subtask_list), 1)
 
     def test_run(self):
         task_info = {'id': 100}


### PR DESCRIPTION
Plain `TaskBase.wait()` always uses the **whole** list of all subtasks as the set of subtasks that should be awaited.  Therefore, it will try to await even tasks that were already awaited in some previous `TaskBase.wait()` call and are no longer present in `self._subtask_list` which will subsequently raise the `ValueError` shown below.

Keep the set of already awaited tasks and skip their IDs when marking newly awaited subtasks as finished.

Fixes the following traceback:
```python
Traceback (most recent call last):
  File "/src/kobo/kobo/worker/taskmanager.py", line 423, in run_task
    task.run()
  File "/src/osh/worker/tasks/task_errata_diff_build.py", line 55, in run
    self.wait()
  File "/src/kobo/kobo/worker/task.py", line 147, in wait
    self._subtask_list.remove(i)
ValueError: list.remove(x): x not in list
```