### PR TITLE
hub: make `Task.save()` atomic

### DIFF
--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -605,6 +605,7 @@ class Task(models.Model):
             return u"#%s [method: %s, state: %s, worker: %s, parent: #%s]" % (self.id, self.method, self.get_state_display(), self.worker, self.parent.id)
         return u"#%s [method: %s, state: %s, worker: %s]" % (self.id, self.method, self.get_state_display(), self.worker)
 
+    @transaction.atomic
     def save(self, *args, **kwargs):
         if self.id is not None:
             self.subtask_count = self.subtasks().count()

--- a/kobo/hub/models.py
+++ b/kobo/hub/models.py
@@ -606,9 +606,8 @@ class Task(models.Model):
         return u"#%s [method: %s, state: %s, worker: %s]" % (self.id, self.method, self.get_state_display(), self.worker)
 
     def save(self, *args, **kwargs):
-        # save to db to precalculate subtask counts and obtain an ID (on insert) for stdout and traceback
-        super(self.__class__, self).save()
-        self.subtask_count = self.subtasks().count()
+        if self.id is not None:
+            self.subtask_count = self.subtasks().count()
         super(self.__class__, self).save()
         self.logs.save()
         if self.parent:


### PR DESCRIPTION
... to ensure that the db operation is atomic.

Fixes: c5d7f8e68a24df08a5425206ae686c34f0ebf135 ("Fix calculating the number of task's subtasks in new Django versions")
Related: https://github.com/release-engineering/kobo/pull/217#discussion_r1300849327