### PR TITLE
hub: support creation of subtasks with an inherited worker from parent task

### DIFF
--- a/kobo/hub/xmlrpc/worker.py
+++ b/kobo/hub/xmlrpc/worker.py
@@ -234,7 +234,8 @@ def get_awaited_tasks(request, awaited_task_list):
 
 
 @validate_worker
-def create_subtask(request, label, method, args, parent_id, subtask_priority = None):
+def create_subtask(request, label, method, args, parent_id, subtask_priority = None,
+                   inherit_worker=False):
     parent_task = Task.objects.get_and_verify(task_id=parent_id, worker=request.worker)
 
     return Task.create_task(
@@ -243,6 +244,7 @@ def create_subtask(request, label, method, args, parent_id, subtask_priority = N
         method,
         args=args,
         parent_id=parent_id,
+        worker_name=(request.worker.name if inherit_worker else None),
         arch_name=parent_task.arch.name,
         channel_name=parent_task.channel.name,
         priority=subtask_priority or parent_task.priority

--- a/kobo/worker/task.py
+++ b/kobo/worker/task.py
@@ -90,12 +90,13 @@ class TaskBase(Plugin):
     def notification(cls, hub, conf, task_info):
         pass
 
-    def spawn_subtask(self, method, args, label="", priority = None):
+    def spawn_subtask(self, method, args, label="", priority = None,
+                      inherit_worker=False):
         """Spawn a new subtask."""
         if self.foreground:
             raise RuntimeError("Foreground tasks can't spawn subtasks.")
 
-        subtask_id = self.hub.worker.create_subtask(label, method, args, self.task_id, priority)
+        subtask_id = self.hub.worker.create_subtask(label, method, args, self.task_id, priority, inherit_worker)
         self._running_subtask_list.append(subtask_id)
         return subtask_id
 

--- a/tests/test_taskbase.py
+++ b/tests/test_taskbase.py
@@ -144,7 +144,8 @@ class TestTaskBase(unittest.TestCase):
         ret_id = t.spawn_subtask('method', [], 'label')
         self.assertEqual(ret_id, subtask_id)
 
-        hub.worker.create_subtask.assert_called_once_with('label', 'method', [], task_id, None)
+        hub.worker.create_subtask.assert_called_once_with(
+                'label', 'method', [], task_id, None, False)
 
     def test_spawn_subtask_foreground_task(self):
         task_info = {'id': 100}

--- a/tests/test_xmlrpc_worker.py
+++ b/tests/test_xmlrpc_worker.py
@@ -900,6 +900,27 @@ class TestXmlRpcWorker(django.test.TransactionTestCase):
         self.assertEqual(t_child.worker, None)
         self.assertEqual(t_child.state, TASK_STATES['FREE'])
 
+    def test_create_subtask_with_worker(self):
+        t_parent = Task.objects.create(
+            worker=self._worker,
+            arch=self._arch,
+            channel=self._channel,
+            owner=self._user,
+            state=TASK_STATES['FREE'],
+        )
+
+        req = _make_request(self._worker)
+        task_id = worker.create_subtask(req, 'Label', 'Method', None, t_parent.id,
+                                        inherit_worker=True)
+        self.assertTrue(task_id > 0)
+
+        t_child = Task.objects.get(id=task_id)
+        self.assertEqual(t_child.parent.id, t_parent.id)
+        self.assertEqual(t_child.label, 'Label')
+        self.assertEqual(t_child.method, 'Method')
+        self.assertEqual(t_child.worker, self._worker)
+        self.assertEqual(t_child.state, TASK_STATES['ASSIGNED'])
+
     def test_create_subtask_if_another_worker_task(self):
         w = Worker.objects.create(
             worker_key='other-worker',

--- a/tests/test_xmlrpc_worker.py
+++ b/tests/test_xmlrpc_worker.py
@@ -897,6 +897,8 @@ class TestXmlRpcWorker(django.test.TransactionTestCase):
         self.assertEqual(t_child.parent.id, t_parent.id)
         self.assertEqual(t_child.label, 'Label')
         self.assertEqual(t_child.method, 'Method')
+        self.assertEqual(t_child.worker, None)
+        self.assertEqual(t_child.state, TASK_STATES['FREE'])
 
     def test_create_subtask_if_another_worker_task(self):
         w = Worker.objects.create(


### PR DESCRIPTION
OpenScanHub expects the parent task and its subtasks to be executed on the
same worker.  However, there is a race with the `assign_task` XML-RPC call
because it does not guarantee that the subtask won't be assigned to another
worker by the hub in the meantime.

This commit adds a support for creation of subtasks pre-assigned to the
same worker executing the parent task, thus, invalidating the necessary
condition for the race described above.

Related: https://github.com/openscanhub/openscanhub/issues/156