### PR TITLE
hub: add menu item for failed tasks.

### DIFF
--- a/kobo/admin/templates/hub/menu.py.template
+++ b/kobo/admin/templates/hub/menu.py.template
@@ -35,6 +35,7 @@ menu = (
     MenuItem("Tasks", "task/index", menu=(
         MenuItem("All", "task/index"),
         MenuItem("Running", "task/running"),
+        MenuItem("Failed", "task/failed"),
         MenuItem("Finished", "task/finished"),
     )),
     MenuItem("Info", "worker/list", menu=(

--- a/kobo/hub/urls/task.py
+++ b/kobo/hub/urls/task.py
@@ -17,6 +17,7 @@ urlpatterns = [
     url(r"^$", TaskListView.as_view(), name="task/index"),
     url(r"^(?P<pk>\d+)/$", TaskDetail.as_view(), name="task/detail"),
     url(r"^running/$", TaskListView.as_view(state=(TASK_STATES["FREE"], TASK_STATES["ASSIGNED"], TASK_STATES["OPEN"]), title=_("Running tasks"), order_by=["id"]), name="task/running"),
+    url(r"^failed/$", TaskListView.as_view(state=(TASK_STATES["FAILED"],), title=_("Failed tasks"), order_by=["-dt_created", "id"]), name="task/failed"),
     url(r"^finished/$", TaskListView.as_view(state=(TASK_STATES["CLOSED"], TASK_STATES["INTERRUPTED"], TASK_STATES["CANCELED"], TASK_STATES["FAILED"]), title=_("Finished tasks"), order_by=["-dt_created", "id"]), name="task/finished"),
     url(r"^(?P<id>\d+)/log/(?P<log_name>.+)$", kobo.hub.views.task_log, name="task/log"),
     url(r"^(?P<id>\d+)/log-json/(?P<log_name>.+)$", kobo.hub.views.task_log_json, name="task/log-json"),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -134,6 +134,15 @@ class TestTaskView(django.test.TransactionTestCase):
         self.assertTrue(self.task3.method not in str(response.content))
         self.assertTrue(self.task4.method not in str(response.content))
 
+    def test_list_failed(self):
+        response = self.client.get('/task/failed/')
+        self.assertEqual(response.status_code, 200)
+        # make sure only failed tasks are listed
+        self.assertTrue(self.task1.get_state_display() not in str(response.content))
+        self.assertTrue(self.task2.get_state_display() not in str(response.content))
+        self.assertTrue(self.task3.get_state_display() not in str(response.content))
+        self.assertTrue(self.task4.get_state_display() in str(response.content))
+
     def test_list_finished(self):
         response = self.client.get('/task/finished/')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This PR adds `task/failed` view so as to allow filtering of failed tasks in the menu item.


see also https://github.com/openscanhub/openscanhub/issues/85