### PR TITLE
upload: fix duplicate detection

### DIFF
--- a/kobo/django/upload/models.py
+++ b/kobo/django/upload/models.py
@@ -63,7 +63,8 @@ class FileUpload(models.Model):
             if "update_fields" in kwargs:
                 kwargs["update_fields"] = {"upload_key"}.union(kwargs["update_fields"])
         if self.state == UPLOAD_STATES['FINISHED']:
-            if FileUpload.objects.filter(state = UPLOAD_STATES['FINISHED'], name = self.name).exclude(id = self.id).count() != 0:
+            if FileUpload.objects.filter(state = UPLOAD_STATES['FINISHED'], name = self.name,
+                                         checksum=self.checksum, target_dir=self.target_dir).exclude(id = self.id).count() != 0:
                 # someone created same upload faster
                 self.state = UPLOAD_STATES['FAILED']
                 if "update_fields" in kwargs:

--- a/kobo/django/upload/views.py
+++ b/kobo/django/upload/views.py
@@ -39,7 +39,7 @@ def file_upload(request):
     try:
         upload = FileUpload.objects.get(id=upload_id, upload_key=upload_key)
     except:
-        return HttpResponseForbidden("Not allowed to upload the file.")
+        return HttpResponseForbidden(b"Not allowed to upload the file.")
 
     upload_path = os.path.join(upload.target_dir, upload.name)
 
@@ -47,7 +47,7 @@ def file_upload(request):
         upload.state = UPLOAD_STATES["FAILED"]
         upload.save()
         # remove file
-        return HttpResponseServerError("File already exists.")
+        return HttpResponseServerError(b"File already exists.")
 
     # TODO: check size
     # don't re-upload FINISHED or STARTED
@@ -72,7 +72,7 @@ def file_upload(request):
         upload.state = UPLOAD_STATES["FAILED"]
         upload.save()
         # remove file
-        return HttpResponseServerError("Checksum mismatch.")
+        return HttpResponseServerError(b"Checksum mismatch.")
 
     if not os.path.isdir(upload.target_dir):
         os.makedirs(upload.target_dir)
@@ -86,6 +86,6 @@ def file_upload(request):
 
     # upload.save can modify state if there is a race
     if upload.state == UPLOAD_STATES['FAILED']:
-        return HttpResponseServerError("Checksum mismatch.")
+        return HttpResponseServerError(b"Checksum mismatch.")
 
-    return HttpResponse("Upload finished.")
+    return HttpResponse(b"Upload finished.")

--- a/kobo/django/upload/views.py
+++ b/kobo/django/upload/views.py
@@ -86,6 +86,6 @@ def file_upload(request):
 
     # upload.save can modify state if there is a race
     if upload.state == UPLOAD_STATES['FAILED']:
-        return HttpResponseServerError(b"Checksum mismatch.")
+        return HttpResponseServerError(b"File already exists.")
 
     return HttpResponse(b"Upload finished.")


### PR DESCRIPTION
Do not classify uploads with different checksums or target directories as duplicates.

@rohanpm: There is no need to create a new release just with this PR.