### PR TITLE
upload: use `copy` instead of `move`

### DIFF
--- a/kobo/django/upload/views.py
+++ b/kobo/django/upload/views.py
@@ -77,7 +77,7 @@ def file_upload(request):
     if not os.path.isdir(upload.target_dir):
         os.makedirs(upload.target_dir)
 
-    shutil.move(tmp_file_name, upload.target_dir)
+    shutil.move(tmp_file_name, upload.target_dir, copy_function=shutil.copy)
     shutil.rmtree(tmp_dir)
 
     upload.state = UPLOAD_STATES["FINISHED"]


### PR DESCRIPTION
... to transfer the upload to its target directory.  For some reason, the `shutil.move` call would fail on the OSH production hub with SELinux enabled with a `Permission denied` error due to some relabelling problems. However, plain copying works fine and it should not introduce any problems because the whole temporary directory with the source upload will be removed anyway.

Related: https://github.com/openscanhub/openscanhub/pull/180