### PR TITLE
hub: fix display of worker arches and channels

### DIFF
--- a/kobo/hub/templates/worker/detail.html
+++ b/kobo/hub/templates/worker/detail.html
@@ -16,7 +16,7 @@
   </tr>
   <tr>
     <th>{% trans "Arches" %}</th>
-    <td>{{ worker.get_arches_display }}</td>
+    <td>{{ worker.arches.all | join:" " }}</td>
   </tr>
   <tr>
     <th>{% trans "Load" %}</th>
@@ -37,7 +37,7 @@
   </tr>
   <tr>
     <th>{% trans "Channels" %}</th>
-    <td>{{ worker.get_channels_display }}</td>
+    <td>{{ worker.channels.all | join:" " }}</td>
   </tr>
 </table>
 


### PR DESCRIPTION
This feature seems to have been broken since the beginning of this project because the `get_{arches,channels}_display` methods were never actually defined.