### PR TITLE
tback: make `Traceback` printing compatible with Python 3 

### DIFF
--- a/kobo/client/__init__.py
+++ b/kobo/client/__init__.py
@@ -510,21 +510,13 @@ class HubProxy(object):
             self._hub.worker.upload_task_log(task_id, remote_file_name, mode, chunk_start, chunk_len, chunk_checksum, encoded_chunk)
 
 
-from six.moves.xmlrpc_client import Fault
-import sys
-
+from xmlrpc.client import Fault
 
 # default implementation of Fault.__repr__ is:
 #    "<Fault %s: %s>" % (self.faultCode, repr(self.faultString))
-# repr of string does not escape newlines ('\n') and produces very ugly output
-# so using direct string is much nicer for users
+# repr of string escapes everything (e.g. newlines) and produces a very ugly
+# output so using it directly is much nicer for users
 def fault_repr(self):
-    fault = self.faultString
-    if sys.version_info[0] > 2 and fault.startswith("b\'Traceback"):
-        # properly deserialize tracebacks
-        import ast
-        fault = ast.literal_eval(fault).decode("unicode-escape")
-
-    return "<Fault %s: %s>" % (self.faultCode, str(fault))
+    return "<Fault %s: %s>" % (self.faultCode, self.faultString)
 
 Fault.__repr__ = fault_repr

--- a/kobo/decorators.py
+++ b/kobo/decorators.py
@@ -62,10 +62,10 @@ def log_traceback(func, log_file):
             import datetime
             import kobo.shortcuts
             import kobo.tback
-            date = datetime.datetime.strftime(datetime.datetime.now(), "%F %R:%S").encode()
-            data = b"--- TRACEBACK BEGIN: " + date + b" ---\n"
+            date = datetime.datetime.strftime(datetime.datetime.now(), "%F %R:%S")
+            data = "--- TRACEBACK BEGIN: " + date + " ---\n"
             data += kobo.tback.Traceback().get_traceback()
-            data += b"--- TRACEBACK END: " + date + b" ---\n\n\n"
+            data += "--- TRACEBACK END: " + date + " ---\n\n\n"
             kobo.shortcuts.save_to_file(log_file, data, append=True)
             raise
     return new_func

--- a/kobo/tback.py
+++ b/kobo/tback.py
@@ -260,7 +260,6 @@ def set_except_hook(logger=None):
         tback.show_locals = True
         logger and logger.error(tback.get_traceback())
         tback.print_traceback()
-        print()
 
     _hook.__doc__ = sys.excepthook.__doc__
     _hook.__name__ = sys.excepthook.__name__

--- a/kobo/tback.py
+++ b/kobo/tback.py
@@ -169,18 +169,8 @@ class Traceback(object):
                                 obj_value_str = self._to_str(obj_value, "%.200r")
                                 result.append("%20s = %s" % ("self." + self._to_str(obj_key), obj_value_str))
                     result.append("</LOCALS>")
-        s = u''
 
-        for i in result:
-            line = i.replace(r'\\n', '\n').replace(r'\n', '\n')
-
-            if type(i) == six.text_type:
-                s += i
-            else:
-                s += six.text_type(str(i), errors='replace')
-            s += '\n'
-
-        return s.encode('ascii', 'replace')
+        return '\n'.join(result)
 
     def print_traceback(self):
         """Print a traceback string to stderr."""

--- a/kobo/worker/logger.py
+++ b/kobo/worker/logger.py
@@ -77,7 +77,7 @@ class LoggingThread(threading.Thread):
                 if self._logger:
                     msg = "\n".join([
                         "Fatal error in LoggingThread",
-                        kobo.tback.Traceback().get_traceback().decode(),
+                        kobo.tback.Traceback().get_traceback(),
                     ])
                     self._logger.log_critical(msg)
                 raise

--- a/kobo/worker/taskmanager.py
+++ b/kobo/worker/taskmanager.py
@@ -445,7 +445,7 @@ class TaskManager(TaskManagerBase):
             message = "ERROR: %s\n" % kobo.tback.get_exception()
             message += "See traceback.log for details (admin only).\n"
             hub.upload_task_log(BytesIO(message.encode()), task.task_id, "error.log")
-            hub.upload_task_log(BytesIO(kobo.tback.Traceback().get_traceback()), task.task_id, "traceback.log", mode=0o600)
+            hub.upload_task_log(BytesIO(kobo.tback.Traceback().get_traceback().encode()), task.task_id, "traceback.log", mode=0o600)
             failed = True
         finally:
             thread.stop()

--- a/tests/test_tback.py
+++ b/tests/test_tback.py
@@ -3,7 +3,6 @@
 
 
 import re
-import six
 import unittest
 
 from kobo.tback import get_traceback, Traceback
@@ -20,40 +19,39 @@ class TestTraceback(unittest.TestCase):
         try:
             raise Exception('Simple text')
         except:
-            str_regexp = re.compile(r'Traceback \(most recent call last\):\n *File ".*test_tback.py", line .+, in test_text\n *raise Exception\(\'Simple text\'\)\n *Exception: Simple text', re.M)
-            bytes_regexp = re.compile(rb'Traceback \(most recent call last\):\n *File ".*test_tback.py", line .+, in test_text\n *raise Exception\(\'Simple text\'\)\n *Exception: Simple text', re.M)
+            regexp = re.compile(r'Traceback \(most recent call last\):\n *File ".*test_tback.py", line .+, in test_text\n *raise Exception\(\'Simple text\'\)\n *Exception: Simple text', re.M)
 
-            self.assertRegex(get_traceback(), str_regexp)
+            self.assertRegex(get_traceback(), regexp)
             tb = Traceback(show_traceback = True, show_code = False, show_locals = False, show_environ = False, show_modules = False)
-            self.assertRegex(tb.get_traceback(), bytes_regexp)
+            self.assertRegex(tb.get_traceback(), regexp)
 
     def test_Traceback(self):
         try:
             raise Exception('Simple text')
         except:
             tb = Traceback(show_traceback = False, show_code = False, show_locals = False, show_environ = False, show_modules = False)
-        self.assertEqual(b'', tb.get_traceback())
+        self.assertEqual('', tb.get_traceback())
         tb.show_code = True
-        self.assertRegex(tb.get_traceback(), re.compile(rb'<CODE>.*--> *\d+ *raise Exception.*<\/CODE>$', re.M | re.S))
+        self.assertRegex(tb.get_traceback(), re.compile(r'<CODE>.*--> *\d+ *raise Exception.*<\/CODE>$', re.M | re.S))
         tb.show_code = False
         tb.show_locals = True
-        self.assertRegex(tb.get_traceback(), re.compile(rb'<LOCALS>.*tb = .*<\/LOCALS>$', re.M | re.S))
+        self.assertRegex(tb.get_traceback(), re.compile(r'<LOCALS>.*tb = .*<\/LOCALS>$', re.M | re.S))
         tb.show_locals = False
         tb.show_environ = True
-        self.assertRegex(tb.get_traceback(), re.compile(rb'<ENVIRON>.*<\/ENVIRON>\n<GLOBALS>.*</GLOBALS>$', re.M | re.S))
+        self.assertRegex(tb.get_traceback(), re.compile(r'<ENVIRON>.*<\/ENVIRON>\n<GLOBALS>.*</GLOBALS>$', re.M | re.S))
         tb.show_environ = False
         tb.show_modules = True
-        self.assertRegex(tb.get_traceback(), re.compile(rb'<MODULES>.*<\/MODULES>$', re.M | re.S))
+        self.assertRegex(tb.get_traceback(), re.compile(r'<MODULES>.*<\/MODULES>$', re.M | re.S))
 
     def test_encoding(self):
         try:
             a = ''.join([chr(i) for i in range(256)])
-            b = u''.join([unichr(i) for i in range(65536)])
+            b = b''.join([chr(i).encode() for i in range(65536)])
             raise Exception()
         except:
             tb = Traceback(show_code = False, show_traceback = False)
         output = tb.get_traceback()
-        self.assertIsInstance(output, six.binary_type)
+        self.assertIsInstance(output, str)
 
     def test_uninitialized_variables(self):
         class Foo(object):


### PR DESCRIPTION
Because `kobo` only supports Python 3.6+, we can just return a
concatenated Unicode string with the given exception.

Fixes the following incorrectly formatted output:
```python
$ cat test.py
from kobo.tback import set_except_hook
set_except_hook()

assert False

$ python3 test.py
b'Traceback (most recent call last):\n  File "/Users/lzaoral/redhat/OpenScanHub/kobo/test.py", line 4, in <module>\n    assert False\nAssertionError\nFrame <module> in /Users/lzaoral/redhat/OpenScanHub/kobo/test.py at line 4\n<CODE>\n       1 from kobo.tback import set_except_hook\n       2 set_except_hook()\n       3 \n-->    4 assert False\n</CODE>\n<LOCALS>\n     __annotations__ = {}\n        __builtins__ = <module \'builtins\' (built-in)>\n          __cached__ = None\n             __doc__ = None\n            __file__ = \'/Users/lzaoral/redhat/OpenScanHub/kobo/test.py\'\n          __loader__ = <_frozen_importlib_external.SourceFileLoader object at 0x100711650>\n            __name__ = \'__main__\'\n         __package__ = None\n            __spec__ = None\n     set_except_hook = <function set_except_hook at 0x10082df80>\n</LOCALS>\n'
```