### PR TITLE
Make LoggingThread recover on all errors [RHELDST-332]

### DIFF
--- a/kobo/worker/logger.py
+++ b/kobo/worker/logger.py
@@ -6,7 +6,6 @@ import time
 import six
 
 from six.moves import queue
-from six.moves.xmlrpc_client import Fault
 from six import BytesIO
 
 import kobo.tback
@@ -67,20 +66,8 @@ class LoggingThread(threading.Thread):
                 self._hub.upload_task_log(BytesIO(self._send_data), self._task_id, "stdout.log", append=True)
                 self._send_time = now
                 self._send_data = b""
-            except Fault:
-                continue
             except Exception:
-                # Any exception other than XML-RPC fault is fatal. Since
-                # upload_task_log is apparently not working, we can't get this
-                # into the task logs, but it should at least be possible for
-                # this to get into the worker's local log file.
-                if self._logger:
-                    msg = "\n".join([
-                        "Fatal error in LoggingThread",
-                        kobo.tback.Traceback().get_traceback(),
-                    ])
-                    self._logger.log_critical(msg)
-                raise
+                continue
 
     def write(self, data):
         """Add data to the queue and set the event for sending queue content."""


### PR DESCRIPTION
Previously, LoggingThread would recover from any XML-RPC fault, but would stop when any other type of exception was encountered. That is a problem, as it means the worker will permanently give up sending messages to the hub when all kinds of temporary issues occur (e.g. a temporary network disruption between worker and hub). The task underneath may continue running for hours, with all log messages being discarded.

Given the nature of this thread, it makes more sense to attempt recovering from all kinds of errors, as we should try hard not to lose log messages from a task.

Fixes https://github.com/release-engineering/kobo/issues/60

(This commit is a reimplementation of
https://github.com/release-engineering/kobo/pull/106)