### PR TITLE
worker: limit the size of Queue in `LoggingThread`

### DIFF
--- a/kobo/worker/logger.py
+++ b/kobo/worker/logger.py
@@ -25,7 +25,8 @@ class LoggingThread(threading.Thread):
         threading.Thread.__init__(self, *args, **kwargs)
         self._hub = hub
         self._task_id = task_id
-        self._queue = queue.Queue()
+        self._buffer_size = kwargs.pop('buffer_size', 256)
+        self._queue = queue.Queue(maxsize=self._buffer_size)
         self._event = threading.Event()
         self._running = True
         self._send_time = 0
@@ -49,7 +50,7 @@ class LoggingThread(threading.Thread):
                 self._event.wait(5)
 
             self._event.clear()
-            while True:
+            for _ in range(self._buffer_size):
                 try:
                     self._send_data += self.read_queue()
                 except queue.Empty:

--- a/kobo/worker/logger.py
+++ b/kobo/worker/logger.py
@@ -68,6 +68,14 @@ class LoggingThread(threading.Thread):
                 self._send_time = now
                 self._send_data = b""
             except Exception:
+                # Log all caught exceptions.
+                if self._logger:
+                    msg = "\n".join([
+                        "Exception in LoggingThread:",
+                        kobo.tback.Traceback().get_traceback(),
+                    ])
+                    self._logger.log_error(msg)
+
                 continue
 
     def write(self, data):


### PR DESCRIPTION
This change fixes two issues:

1. By limiting the maximum size of the Queue, we avoid consuming all
   available memory on given machine to store its contents.

2. By limiting the amount of retrieved elements from the Queue, we avoid
   consuming all available memory to construct the byte string to send and
   we avoid stalling the upload of logs to the hub.

Also, log all skipped exceptions caught in `LoggingThread` to ease debugging.