### PR TITLE
hub: do not insert extra newlines to logs on page reloads

### DIFF
--- a/kobo/hub/templates/task/log.html
+++ b/kobo/hub/templates/task/log.html
@@ -14,8 +14,5 @@ document.log_watcher.watch();
 <h2>{% trans 'Task' %} #{{ task.id }} - {{ log_name }}</h2>
 <a href="{% url 'task/detail' task.id %}">{% trans "back to task" %} #{{ task.id }}</a><br />
 <a href="?format=raw">{% trans 'download' %}</a>
-<pre class="log" id="log">
-{{ content }}
-</pre>
-
+<pre class="log" id="log">{{ content }}</pre>
 {% endblock %}

--- a/tests/test_view_log.py
+++ b/tests/test_view_log.py
@@ -196,7 +196,7 @@ class TestViewLog(django.test.TransactionTestCase):
         # The response is expected to be wrapped in some view.
         # We are only doing a very basic verification of the view here
         self.assertTrue(content.startswith('<!DOCTYPE html'))
-        self.assertTrue((small_log_content() + "\n</pre>") in content, content)
+        self.assertTrue((small_log_content() + "</pre>") in content, content)
 
         # No trimming necessary
         self.assertFalse('...trimmed, download required for full log' in content)
@@ -210,7 +210,7 @@ class TestViewLog(django.test.TransactionTestCase):
         )
 
         self.assertTrue(content.startswith('<!DOCTYPE html'))
-        self.assertTrue((tiny_log_content() + "\n</pre>") in content, content)
+        self.assertTrue((tiny_log_content() + "</pre>") in content, content)
         self.assertFalse('...trimmed, download required for full log' in content)
 
     @profile


### PR DESCRIPTION
Any text between the `<pre>` tags was interpreted literally, including line feed characters.