### PR TITLE
hub: return only OPEN tasks in `worker.get_worker_tasks`

### DIFF
--- a/kobo/hub/xmlrpc/worker.py
+++ b/kobo/hub/xmlrpc/worker.py
@@ -58,12 +58,16 @@ def get_worker_id(request):
 @validate_worker
 def get_worker_tasks(request):
     """
-    Get list of tasks running on a worker.
+    Get list of OPEN tasks executed on a worker.
 
     @rtype: list
     """
     task_list = []
-    for task in request.worker.running_tasks().order_by("-exclusive", "-awaited", "id"):
+
+    # Worker.running_tasks returns both OPEN and ASSIGNED tasks but all calls
+    # by the worker assume that only OPEN tasks will be returned.
+    # See: https://github.com/release-engineering/kobo/pull/251#issue-2183712995
+    for task in request.worker.running_tasks().filter(state=TASK_STATES['OPEN']).order_by("-exclusive", "-awaited", "id"):
         task_info = task.export()
 
         # set wakeup alert

--- a/kobo/worker/taskmanager.py
+++ b/kobo/worker/taskmanager.py
@@ -300,9 +300,10 @@ class TaskManager(TaskManagerBase):
             awaited_task_list = self.hub.worker.get_awaited_tasks(task_list)
             self.log_debug("Current awaited tasks: %r" % [ti["id"] for ti in awaited_task_list])
 
-            # process assigned tasks first
+            # process awaited tasks that could be transitioned to the OPEN state
             for task_info in awaited_task_list:
-                self.take_task(task_info)
+                if task_info['state'] in (TASK_STATES["FREE"], TASK_STATES["ASSIGNED"]):
+                    self.take_task(task_info)
 
             return
 

--- a/tests/test_xmlrpc_worker.py
+++ b/tests/test_xmlrpc_worker.py
@@ -89,11 +89,8 @@ class TestXmlRpcWorker(django.test.TransactionTestCase):
         req = _make_request(self._worker)
         tasks = worker.get_worker_tasks(req)
 
-        self.assertEqual(len(tasks), 2)
-        self.assertTrue(tasks[0]['id'] < tasks[1]['id'])
-
-        for task in tasks:
-            self.assertTrue(task['state'] in [TASK_STATES['ASSIGNED'], TASK_STATES['OPEN']])
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]['state'], TASK_STATES['OPEN'])
 
     def test_get_worker_tasks_check_wait(self):
         t_parent = Task.objects.create(


### PR DESCRIPTION
Previously, this XML-RPC method would return `ASSIGNED` tasks as well which is
semantically incorrect.

Moreover, workers have always assumed that the list will contain `OPEN` tasks
only.  Therefore, this also fixes two bugs:

1. A worker with a locked `TaskManager` would never terminate, because the
   returned list of "running tasks" would never be emptied if there are some
   tasks that are assigned to the given worker and are not awaited.

2. `TaskManager.update_tasks` would append all `ASSIGNED` tasks to
   `TaskManager.task_dict`.  Therefore, the worker process would crash during
   clean-up if it was terminated and some `ASSIGNED` tasks have not been opened
   yet:
   ```
   ^C2024-03-13 09:02:12 [INFO    ] Exiting...
   2024-03-13 09:02:12 [INFO    ] kill_group: Process (pgrp 94) exited
   2024-03-13 09:02:12 [INFO    ] kill_group: Process (pgrp 2) exists
   2024-03-13 09:02:12 [INFO    ] kill_group: Sent signal 15 to process (pgrp 2)
   ...
   2024-03-13 09:02:14 [INFO    ] kill_group: process 11 was killed by signal 15
   2024-03-13 09:02:14 [INFO    ] kill_group: process 12 was killed by signal 9
   2024-03-13 09:02:14 [INFO    ] kill_group: Killed process (pgrp 3)
   Traceback (most recent call last):
     File "/src/kobo/kobo/worker/main.py", line 72, in main_loop
       tm.sleep()
     File "/src/kobo/kobo/worker/taskmanager.py", line 152, in sleep
       time.sleep(self.conf.get("SLEEP_TIME", 20))
   KeyboardInterrupt
   During handling of the above exception, another exception occurred:
   Traceback (most recent call last):
     File "osh/worker/osh-worker", line 53, in <module>
       main()
     File "osh/worker/osh-worker", line 40, in main
       kobo.worker.main.main(conf, None, OSHTaskManager)
     File "/src/kobo/kobo/worker/main.py", line 132, in main
       main_loop(conf, foreground=True, task_manager_class=task_manager_class)
     File "/src/kobo/kobo/worker/main.py", line 84, in main_loop
       tm.shutdown()
     File "/src/kobo/kobo/worker/taskmanager.py", line 524, in shutdown
       self.cleanup_task(task_id)
     File "/src/kobo/kobo/worker/taskmanager.py", line 500, in cleanup_task
       success = kill_process_group(self.pid_dict[task_id], logger=self._logger)
   KeyError: 39
   ```

This PR also fixes related bug when the worker tries to open already opened or finished tasks.