### PR TITLE
hub: fix display of permissions in user details template

### DIFF
--- a/kobo/hub/templates/user/detail.html
+++ b/kobo/hub/templates/user/detail.html
@@ -17,15 +17,15 @@
   </tr>
   <tr>
     <th>{% trans "Admin" %}</th>
-    <td>{% if user.is_superuser %}<span class="FREE">YES</span>{% else %}<span class="FAILED">NO</span>{% endif %}</td>
+    <td>{% if usr.is_superuser %}<span class="FREE">YES</span>{% else %}<span class="FAILED">NO</span>{% endif %}</td>
   </tr>
   <tr>
     <th>{% trans "Staff" %}</th>
-    <td>{% if user.is_staff %}<span class="FREE">YES</span>{% else %}<span class="FAILED">NO</span>{% endif %}</td>
+    <td>{% if usr.is_staff %}<span class="FREE">YES</span>{% else %}<span class="FAILED">NO</span>{% endif %}</td>
   </tr>
   <tr>
     <th>{% trans "Active" %}</th>
-    <td>{% if user.is_active %}<span class="FREE">YES</span>{% else %}<span class="FAILED">NO</span>{% endif %}</td>
+    <td>{% if usr.is_active %}<span class="FREE">YES</span>{% else %}<span class="FAILED">NO</span>{% endif %}</td>
   </tr>
   <tr>
     <th>{% trans "Tasks" %}</th>


### PR DESCRIPTION
Previously, the attributes of the actual user accessing the website were shown and not those of the selected one.