### PR TITLE
Add option for get_worker_tasks to also return ASSIGNED tasks

### DIFF
--- a/tests/test_xmlrpc_worker.py
+++ b/tests/test_xmlrpc_worker.py
@@ -91,6 +91,25 @@ class TestXmlRpcWorker(django.test.TransactionTestCase):
 
         self.assertEqual(len(tasks), 1)
         self.assertEqual(tasks[0]['state'], TASK_STATES['OPEN'])
+    
+    def test_get_worker_tasks_assigned(self):
+        for state in TASK_STATES:
+            Task.objects.create(
+                worker=self._worker,
+                arch=self._arch,
+                channel=self._channel,
+                owner=self._user,
+                state=TASK_STATES[state],
+            )
+
+        req = _make_request(self._worker)
+        tasks = worker.get_worker_tasks(req, True)
+
+        self.assertEqual(len(tasks), 2)
+        self.assertTrue(tasks[0]['id'] < tasks[1]['id'])
+
+        for task in tasks:
+            self.assertTrue(task['state'] in [TASK_STATES['ASSIGNED'], TASK_STATES['OPEN']])
 
     def test_get_worker_tasks_check_wait(self):
         t_parent = Task.objects.create(


### PR DESCRIPTION
This behavior was recently changed in [1], where this function now only returns OPEN tasks. This caused a regression in our service - which uses a custom task manager. Add an parameter to restore the old behavior. The parameter will be unused by default, so the default behavior remains unchanged.

[1]: https://github.com/release-engineering/kobo/pull/251

Refers to CLOUDDST-23359