### PR TITLE
pkgset.FileCache: implement __contains__ for efficiency

### DIFF
--- a/kobo/pkgset.py
+++ b/kobo/pkgset.py
@@ -229,6 +229,9 @@ class FileCache(object):
     def __setitem__(self, name, value):
         self.file_cache[os.path.abspath(name)] = value
 
+    def __contains__(self, item):
+        return item in self.file_cache
+
     def __iter__(self):
         return iter(self.file_cache)
 

--- a/tests/test_pkgset.py
+++ b/tests/test_pkgset.py
@@ -4,6 +4,7 @@
 
 from __future__ import print_function
 import unittest
+import unittest.mock
 
 import os
 import warnings
@@ -217,6 +218,18 @@ class TestFileCacheClass(unittest.TestCase):
         self.assertEqual(len(items), 2)
         self.assertTrue(self.file1 in items)
         self.assertTrue(self.file2 in items)
+
+    def test_contains(self):
+        open(self.file1, "w").write("hello\n")
+        open(self.file2, "w").write("hello\n")
+
+        self.cache = FileCache()
+        wrap1 = self.cache.add(self.file1)
+        wrap2 = self.cache.add(self.file2)
+
+        with unittest.mock.patch("kobo.pkgset.FileCache.__iter__", side_effect=ValueError):
+            self.assertTrue(self.file1 in self.cache)
+            self.assertTrue(self.file2 in self.cache)
 
     def test_remove_by_file_path(self):
         self.test_add_two_different_files()


### PR DESCRIPTION
See https://pagure.io/pungi/pull-request/1796 . We figured out there that `foo in somefilecache` works, but is much less performant than `foo in somefilecache.file_cache`, because the latter hits the efficient `__contains__` method that Python dicts have, but the former winds up iterating over the dict's keys via `FileCache.__iter__`. In an extreme case, this was making something take 20 minutes instead of 3 seconds.

Users can avoid this by just hitting the `file_cache` directly as in the PR, but to fix this for any other users without them having to change, let's implement `__contains__` in `FileCache` by just passing it through to the dict.