### PR TITLE
Add  transport args as a kwarg for HubProxy [RHELDST-27818]

### DIFF
--- a/kobo/client/__init__.py
+++ b/kobo/client/__init__.py
@@ -129,7 +129,8 @@ class ClientCommand(kobo.cli.Command):
 class HubProxy(object):
     """A Hub client (thin ServerProxy wrapper)."""
 
-    def __init__(self, conf, client_type=None, logger=None, transport=None, auto_logout=None, **kwargs):
+    def __init__(self, conf, client_type=None, logger=None, transport=None,
+                 auto_logout=None, transport_args=None, **kwargs):
         self._conf = kobo.conf.PyConfigParser()
         self._hub = None
 
@@ -157,7 +158,7 @@ class HubProxy(object):
         if transport is not None:
             self._transport = transport
         else:
-            transport_args = {}
+            transport_args = transport_args or {}
             if self._hub_url.startswith("https://"):
                 TransportClass = kobo.xmlrpc.retry_request_decorator(kobo.xmlrpc.SafeCookieTransport)
                 if hasattr(ssl, 'create_default_context'):

--- a/tests/test_hubproxy.py
+++ b/tests/test_hubproxy.py
@@ -237,3 +237,18 @@ def test_proxies_to_xmlrpc(requests_session):
     # Last call should have invoked the method I requested
     (_, request_xml) = transport.fake_transport_calls[-1]
     assert b'some_obj.some_method' in request_xml
+
+
+def test_pass_transport_args(requests_session):
+    """HubProxy proxies to underlying XML-RPC ServerProxy"""
+    conf = PyConfigParser()
+    conf.load_from_dict({"HUB_URL": 'https://example.com/hub'})
+    transport_args = {"retry_count": 2, "retry_timeout": 45}
+    with mock.patch(
+            "kobo.xmlrpc.SafeCookieTransport") as mock_transport_class, mock.patch(
+            "kobo.xmlrpc.retry_request_decorator",
+            return_value=mock_transport_class):
+        HubProxy(conf, transport_args=transport_args)
+        mock_transport_class.assert_called_with(context=mock.ANY,
+                                                retry_count=2,
+                                                retry_timeout=45)


### PR DESCRIPTION
We would like to be able to set the retry parameters for xml-rpc calls in pub. The retry_request decorator accepts kwargs for setting the retry parameters, but the HubProxy class doesn't make use of these.

This change allows users to provide transport class args as a kwarg, so we can modify the retry behaviour.