### PR TITLE
Add XMLRPC Fault exception to retry decorator

### DIFF
--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -479,7 +479,8 @@ def retry_request_decorator(transport_class):
                 except KeyboardInterrupt:
                     raise
                 except (socket.error, socket.herror, socket.gaierror, socket.timeout,
-                        httplib.CannotSendRequest, xmlrpclib.ProtocolError) as ex:
+                        httplib.CannotSendRequest, xmlrpclib.ProtocolError,
+                        xmlrpclib.Fault) as ex:
                     if i >= self.retry_count:
                         raise
                     retries_left = self.retry_count - i

--- a/kobo/xmlrpc.py
+++ b/kobo/xmlrpc.py
@@ -481,6 +481,9 @@ def retry_request_decorator(transport_class):
                 except (socket.error, socket.herror, socket.gaierror, socket.timeout,
                         httplib.CannotSendRequest, xmlrpclib.ProtocolError,
                         xmlrpclib.Fault) as ex:
+                    if type(ex) is xmlrpclib.Fault and \
+                            "PermissionDenied" not in ex.faultString:
+                        raise
                     if i >= self.retry_count:
                         raise
                     retries_left = self.retry_count - i


### PR DESCRIPTION
We have seen several cases where Pub tasks fail because the worker gets a permission denied error, immediately after successfully logging in. We believe that these are false negatives, which can be resolved by a simple retry.