### PR TITLE
hub: make middleware code compatible with Django 5.2

### DIFF
--- a/kobo/django/auth/middleware.py
+++ b/kobo/django/auth/middleware.py
@@ -1,9 +1,8 @@
 from django.contrib.auth.middleware import RemoteUserMiddleware
-from django.utils.deprecation import MiddlewareMixin
 
 from kobo.django.helpers import call_if_callable
 
-class LimitedRemoteUserMiddleware(RemoteUserMiddleware, MiddlewareMixin):
+class LimitedRemoteUserMiddleware(RemoteUserMiddleware):
     '''
     Same behaviour as RemoteUserMiddleware except that it doesn't logout user
     if is already logged in.

--- a/kobo/django/menu/middleware.py
+++ b/kobo/django/menu/middleware.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from django.utils.deprecation import MiddlewareMixin
-
 from kobo.django.menu import menu
 
 
@@ -20,10 +18,18 @@ class LazyMenu(object):
         return request._cached_menu
 
 
-class MenuMiddleware(MiddlewareMixin):
+class MenuMiddleware():
     """
     @summary: Middleware for menu object.
     """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        self.process_request(request)
+        response = self.get_response(request)
+        return response
+
     def process_request(self, request):
         """
         @summary: Adds menu to request object

--- a/kobo/hub/middleware.py
+++ b/kobo/hub/middleware.py
@@ -2,8 +2,6 @@
 
 from __future__ import absolute_import
 
-from django.utils.deprecation import MiddlewareMixin
-
 from .models import Worker
 
 
@@ -26,12 +24,20 @@ class LazyWorker(object):
         return request._cached_worker
 
 
-class WorkerMiddleware(MiddlewareMixin):
+class WorkerMiddleware():
     """Sets a request.worker.
 
     - Worker instance if username exists in database
     - None otherwise
     """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        self.process_request(request)
+        response = self.get_response(request)
+        return response
 
     def process_request(self, request):
         assert hasattr(request, "user"), "Worker middleware requires authentication middleware to be installed. Also make sure the database is set and writable."


### PR DESCRIPTION
Remove the usage of `MiddlewareMixin` (which was mainly needed for Django 1.9 and older but kobo no longer supports these releases) and replace it with a bit more modern alternative.

Resolves: https://github.com/openscanhub/openscanhub/issues/320