### PR TITLE
hub: use .save() with enable-worker so that ready state is refreshed

### DIFF
--- a/kobo/hub/xmlrpc/client.py
+++ b/kobo/hub/xmlrpc/client.py
@@ -39,14 +39,24 @@ def shutdown_worker(request, worker_name, kill=False):
 def enable_worker(request, worker_name):
     """enable_worker(worker_name): none
     """
-    models.Worker.objects.filter(name=worker_name).update(enabled=True)
+    try:
+        worker = models.Worker.objects.get(name=worker_name)
+        worker.enabled = True
+        worker.save()
+    except ObjectDoesNotExist:
+        pass
 
 
 @admin_required
 def disable_worker(request, worker_name):
     """disable_worker(worker_name, kill): None
     """
-    models.Worker.objects.filter(name=worker_name).update(enabled=False)
+    try:
+        worker = models.Worker.objects.get(name=worker_name)
+        worker.enabled = False
+        worker.save()
+    except ObjectDoesNotExist:
+        pass
 
 def get_worker_info(request, worker_name):
     try:


### PR DESCRIPTION
When enable-worker and disable-worker commands are used, they update the enabled field in Worker objects directly, bypassing the .save() method, which is the only place where the ready field is recalculated.

This change uses .save() to make the enabled state change, so that ready state is recalculated. This fixes an issue where if a worker is disabled, then later re-enabled, it can get stuck in a non-ready state.

CC @kdudka 