### PR TITLE
clean up the outdated testenv in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Don't forget to update GA config when changing this
-envlist = {py36, py38, py39, py310, py311}-{django2, django3}, {py38, py39, py310, py311, py312}-django4, {py310, py311, py312}-django5, py39-bandit
+envlist = {py36, py39, py310, py311}-{django2, django3}, {py39, py310, py311, py312}-django4, {py310, py311, py312}-django5, py39-bandit
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.8 support has been dropped from kobo. Update tox.ini to remove the correspondent test environment to reflect the current support matrix.